### PR TITLE
feat: Add user info API integration with /me endpoint

### DIFF
--- a/api/src/main/java/ink/trmnl/android/buddy/api/TrmnlApiService.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/TrmnlApiService.kt
@@ -4,6 +4,7 @@ import com.slack.eithernet.ApiResult
 import ink.trmnl.android.buddy.api.models.ApiError
 import ink.trmnl.android.buddy.api.models.DeviceResponse
 import ink.trmnl.android.buddy.api.models.DevicesResponse
+import ink.trmnl.android.buddy.api.models.UserResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Path
@@ -115,4 +116,58 @@ interface TrmnlApiService {
         @Path("id") id: Int,
         @Header("Authorization") authorization: String
     ): ApiResult<DeviceResponse, ApiError>
+    
+    // ========================================
+    // Users API
+    // ========================================
+    
+    /**
+     * Get information about the authenticated user.
+     *
+     * Retrieves the profile information for the currently authenticated user,
+     * including their name, email, timezone, and API key.
+     *
+     * Requires authentication via Bearer token.
+     *
+     * @param authorization Bearer token with format "Bearer user_xxxxxx"
+     * @return ApiResult containing user data or error
+     *
+     * Example response:
+     * ```json
+     * {
+     *   "data": {
+     *     "name": "Jim Bob",
+     *     "email": "jimbob@gmail.net",
+     *     "first_name": "Jim",
+     *     "last_name": "Bob",
+     *     "locale": "en",
+     *     "time_zone": "Eastern Time (US & Canada)",
+     *     "time_zone_iana": "America/New_York",
+     *     "utc_offset": -14400,
+     *     "api_key": "user_xxxxxx"
+     *   }
+     * }
+     * ```
+     *
+     * Example usage:
+     * ```kotlin
+     * when (val result = api.userInfo("Bearer user_abc123")) {
+     *     is ApiResult.Success -> {
+     *         val user = result.value.data
+     *         println("Hello, ${user.firstName}!")
+     *     }
+     *     is ApiResult.Failure.HttpFailure -> when (result.code) {
+     *         401 -> println("Unauthorized - invalid API key")
+     *         else -> println("HTTP error: ${result.code}")
+     *     }
+     *     is ApiResult.Failure.NetworkFailure -> println("Network error")
+     *     is ApiResult.Failure.ApiFailure -> println("API error: ${result.error}")
+     *     is ApiResult.Failure.UnknownFailure -> println("Unknown error")
+     * }
+     * ```
+     */
+    @GET("me")
+    suspend fun userInfo(
+        @Header("Authorization") authorization: String
+    ): ApiResult<UserResponse, ApiError>
 }

--- a/api/src/main/java/ink/trmnl/android/buddy/api/TrmnlDeviceRepository.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/TrmnlDeviceRepository.kt
@@ -2,6 +2,7 @@ package ink.trmnl.android.buddy.api
 
 import com.slack.eithernet.ApiResult
 import ink.trmnl.android.buddy.api.models.Device
+import ink.trmnl.android.buddy.api.models.User
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -132,6 +133,48 @@ class TrmnlDeviceRepository(
                 val weakWifiDevices = result.value.filter { it.isWifiWeak() }
                 ApiResult.success(weakWifiDevices)
             }
+            is ApiResult.Failure -> result
+        }
+    }
+    
+    /**
+     * Get information about the authenticated user.
+     *
+     * Makes an API call to `/me` and returns the user profile information.
+     *
+     * @return ApiResult containing user data or error
+     *
+     * Example usage:
+     * ```kotlin
+     * val repository = TrmnlDeviceRepository(apiService, "user_abc123")
+     * when (val result = repository.userInfo()) {
+     *     is ApiResult.Success -> {
+     *         val user = result.value
+     *         println("Hello, ${user.firstName} ${user.lastName}!")
+     *         println("Email: ${user.email}")
+     *         println("Timezone: ${user.timeZoneIana}")
+     *     }
+     *     is ApiResult.Failure.HttpFailure -> {
+     *         when (result.code) {
+     *             401 -> println("Unauthorized - invalid API key")
+     *             else -> println("HTTP Error: ${result.code}")
+     *         }
+     *     }
+     *     is ApiResult.Failure.NetworkFailure -> {
+     *         println("Network Error: ${result.error}")
+     *     }
+     *     is ApiResult.Failure.ApiFailure -> {
+     *         println("API Error: ${result.error}")
+     *     }
+     *     is ApiResult.Failure.UnknownFailure -> {
+     *         println("Unknown Error: ${result.error}")
+     *     }
+     * }
+     * ```
+     */
+    suspend fun userInfo(): ApiResult<User, *> = withContext(Dispatchers.IO) {
+        when (val result = apiService.userInfo(authHeader)) {
+            is ApiResult.Success -> ApiResult.success(result.value.data)
             is ApiResult.Failure -> result
         }
     }

--- a/api/src/main/java/ink/trmnl/android/buddy/api/models/User.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/models/User.kt
@@ -1,0 +1,50 @@
+package ink.trmnl.android.buddy.api.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * User data model representing a TRMNL user account.
+ *
+ * This model is returned by the `/me` endpoint to provide information
+ * about the currently authenticated user.
+ *
+ * @property name Full name of the user
+ * @property email Email address
+ * @property firstName First name
+ * @property lastName Last name
+ * @property locale User's locale (e.g., "en")
+ * @property timeZone Time zone name (e.g., "Eastern Time (US & Canada)")
+ * @property timeZoneIana IANA time zone identifier (e.g., "America/New_York")
+ * @property utcOffset UTC offset in seconds (e.g., -14400 for EST)
+ * @property apiKey User's API key for authentication
+ */
+@Serializable
+data class User(
+    @SerialName("name")
+    val name: String,
+    
+    @SerialName("email")
+    val email: String,
+    
+    @SerialName("first_name")
+    val firstName: String,
+    
+    @SerialName("last_name")
+    val lastName: String,
+    
+    @SerialName("locale")
+    val locale: String,
+    
+    @SerialName("time_zone")
+    val timeZone: String,
+    
+    @SerialName("time_zone_iana")
+    val timeZoneIana: String,
+    
+    @SerialName("utc_offset")
+    val utcOffset: Int,
+    
+    @SerialName("api_key")
+    val apiKey: String,
+)

--- a/api/src/main/java/ink/trmnl/android/buddy/api/models/UserResponse.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/models/UserResponse.kt
@@ -1,0 +1,17 @@
+package ink.trmnl.android.buddy.api.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Response wrapper for the `/me` API endpoint.
+ *
+ * The TRMNL API wraps single object responses in a `data` field for consistency.
+ *
+ * @property data The user data
+ */
+@Serializable
+data class UserResponse(
+    @SerialName("data")
+    val data: User,
+)

--- a/api/src/test/java/ink/trmnl/android/buddy/api/TrmnlApiServiceTest.kt
+++ b/api/src/test/java/ink/trmnl/android/buddy/api/TrmnlApiServiceTest.kt
@@ -394,4 +394,232 @@ class TrmnlApiServiceTest {
         assertEquals("Low", device.getBatteryStatus())
         assertEquals("Weak", device.getWifiStatus())
     }
+
+    // ========================================
+    // /me Endpoint Tests
+    // ========================================
+
+    @Test
+    fun `userInfo returns success with user data`() = runTest {
+        // Given: Mock server returns successful user response
+        val responseBody = """
+            {
+              "data": {
+                "name": "Jim Bob",
+                "email": "jimbob@gmail.net",
+                "first_name": "Jim",
+                "last_name": "Bob",
+                "locale": "en",
+                "time_zone": "Eastern Time (US & Canada)",
+                "time_zone_iana": "America/New_York",
+                "utc_offset": -14400,
+                "api_key": "user_abc123"
+              }
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(responseBody)
+                .addHeader("Content-Type", "application/json")
+        )
+
+        // When: Call userInfo
+        val result = apiService.userInfo("Bearer user_abc123")
+
+        // Then: Verify success result with correct user data
+        assertTrue("Result should be Success", result is ApiResult.Success)
+        val successResult = result as ApiResult.Success
+
+        val user = successResult.value.data
+        assertEquals("Jim Bob", user.name)
+        assertEquals("jimbob@gmail.net", user.email)
+        assertEquals("Jim", user.firstName)
+        assertEquals("Bob", user.lastName)
+        assertEquals("en", user.locale)
+        assertEquals("Eastern Time (US & Canada)", user.timeZone)
+        assertEquals("America/New_York", user.timeZoneIana)
+        assertEquals(-14400, user.utcOffset)
+        assertEquals("user_abc123", user.apiKey)
+
+        // Verify request was made correctly
+        val request = mockWebServer.takeRequest()
+        assertEquals("/me", request.path)
+        assertEquals("GET", request.method)
+        assertEquals("Bearer user_abc123", request.getHeader("Authorization"))
+    }
+
+    @Test
+    fun `userInfo returns 401 unauthorized with invalid token`() = runTest {
+        // Given: Mock server returns 401 Unauthorized
+        val errorBody = """{"error": "Unauthorized"}"""
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(401)
+                .setBody(errorBody)
+                .addHeader("Content-Type", "application/json")
+        )
+
+        // When: Call userInfo with invalid token
+        val result = apiService.userInfo("Bearer invalid_token")
+
+        // Then: Verify HttpFailure with 401 status
+        assertTrue("Result should be HttpFailure", result is ApiResult.Failure.HttpFailure)
+        val failureResult = result as ApiResult.Failure.HttpFailure
+        assertEquals(401, failureResult.code)
+    }
+
+    @Test
+    fun `userInfo handles different time zones correctly`() = runTest {
+        // Given: Mock server returns user with Pacific time zone
+        val responseBody = """
+            {
+              "data": {
+                "name": "Alice Smith",
+                "email": "alice@example.com",
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "locale": "en",
+                "time_zone": "Pacific Time (US & Canada)",
+                "time_zone_iana": "America/Los_Angeles",
+                "utc_offset": -28800,
+                "api_key": "user_xyz789"
+              }
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(responseBody)
+        )
+
+        // When: Call userInfo
+        val result = apiService.userInfo("Bearer user_xyz789")
+
+        // Then: Verify Pacific timezone data
+        assertTrue(result is ApiResult.Success)
+        val user = (result as ApiResult.Success).value.data
+
+        assertEquals("Pacific Time (US & Canada)", user.timeZone)
+        assertEquals("America/Los_Angeles", user.timeZoneIana)
+        assertEquals(-28800, user.utcOffset) // PST offset
+    }
+
+    @Test
+    fun `userInfo handles international users correctly`() = runTest {
+        // Given: Mock server returns user with international locale and timezone
+        val responseBody = """
+            {
+              "data": {
+                "name": "Hans Müller",
+                "email": "hans@example.de",
+                "first_name": "Hans",
+                "last_name": "Müller",
+                "locale": "de",
+                "time_zone": "Berlin",
+                "time_zone_iana": "Europe/Berlin",
+                "utc_offset": 3600,
+                "api_key": "user_de123"
+              }
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(responseBody)
+        )
+
+        // When: Call userInfo
+        val result = apiService.userInfo("Bearer user_de123")
+
+        // Then: Verify international user data
+        assertTrue(result is ApiResult.Success)
+        val user = (result as ApiResult.Success).value.data
+
+        assertEquals("Hans Müller", user.name)
+        assertEquals("de", user.locale)
+        assertEquals("Europe/Berlin", user.timeZoneIana)
+        assertEquals(3600, user.utcOffset) // CET offset
+    }
+
+    @Test
+    fun `userInfo handles server errors correctly`() = runTest {
+        // Given: Mock server returns 500 Internal Server Error
+        val errorBody = """{"error": "Internal server error"}"""
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(500)
+                .setBody(errorBody)
+        )
+
+        // When: Call userInfo
+        val result = apiService.userInfo("Bearer user_abc123")
+
+        // Then: Verify HttpFailure with 500 status
+        assertTrue("Result should be HttpFailure", result is ApiResult.Failure.HttpFailure)
+        val failureResult = result as ApiResult.Failure.HttpFailure
+        assertEquals(500, failureResult.code)
+    }
+
+    @Test
+    fun `userInfo handles network failures`() = runTest {
+        // Given: Mock server is shut down (simulating network failure)
+        mockWebServer.shutdown()
+
+        // When: Call userInfo
+        val result = apiService.userInfo("Bearer user_abc123")
+
+        // Then: Verify NetworkFailure
+        assertTrue(
+            "Result should be NetworkFailure or UnknownFailure",
+            result is ApiResult.Failure.NetworkFailure || result is ApiResult.Failure.UnknownFailure
+        )
+    }
+
+    @Test
+    fun `userInfo parses all user fields correctly`() = runTest {
+        // Given: Mock server returns complete user data with all fields
+        val responseBody = """
+            {
+              "data": {
+                "name": "Test User",
+                "email": "test@example.com",
+                "first_name": "Test",
+                "last_name": "User",
+                "locale": "en",
+                "time_zone": "Central Time (US & Canada)",
+                "time_zone_iana": "America/Chicago",
+                "utc_offset": -21600,
+                "api_key": "user_test123"
+              }
+            }
+        """.trimIndent()
+
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(responseBody)
+        )
+
+        // When: Call userInfo
+        val result = apiService.userInfo("Bearer user_test123")
+
+        // Then: Verify all fields are parsed
+        assertTrue(result is ApiResult.Success)
+        val user = (result as ApiResult.Success).value.data
+
+        assertNotNull("Name should not be null", user.name)
+        assertNotNull("Email should not be null", user.email)
+        assertNotNull("First name should not be null", user.firstName)
+        assertNotNull("Last name should not be null", user.lastName)
+        assertNotNull("Locale should not be null", user.locale)
+        assertNotNull("Time zone should not be null", user.timeZone)
+        assertNotNull("Time zone IANA should not be null", user.timeZoneIana)
+        assertNotNull("API key should not be null", user.apiKey)
+    }
 }


### PR DESCRIPTION
## 📋 Summary

This PR integrates the `/me` API endpoint into the TRMNL Android Buddy app, enabling retrieval of authenticated user profile information.

## 🎯 What's Changed

### New Models
- ✅ **User.kt** - Complete user profile model with all fields from API spec
  - name, email, firstName, lastName
  - locale, timeZone, timeZoneIana, utcOffset
  - apiKey
- ✅ **UserResponse.kt** - Response wrapper following TRMNL API pattern

### API Integration
- ✅ **TrmnlApiService.kt** - Added `userInfo()` endpoint
  - Type-safe error handling with EitherNet
  - Comprehensive KDoc with examples
  - Bearer token authentication
- ✅ **TrmnlDeviceRepository.kt** - Added `userInfo()` repository method
  - Unwraps response for simplified usage
  - Executes on IO dispatcher
  - Full documentation with usage examples

### Test Coverage
Added 7 comprehensive test cases in **TrmnlApiServiceTest.kt**:
1. ✅ Success case with complete user data
2. ✅ 401 Unauthorized error handling
3. ✅ Different timezone support (Pacific)
4. ✅ International users (German locale/timezone)
5. ✅ Server error handling (500)
6. ✅ Network failure handling
7. ✅ Complete field parsing validation

## 🧪 Testing

All tests passing:
```bash
./gradlew formatKotlin  # ✅ PASSED
./gradlew :api:test     # ✅ PASSED (all 7 new tests green)
```

## 📖 Usage Example

```kotlin
// Using the repository (recommended)
val repository = TrmnlDeviceRepository(apiService, "user_abc123")
when (val result = repository.userInfo()) {
    is ApiResult.Success -> {
        val user = result.value
        println("Hello, ${user.firstName} ${user.lastName}!")
        println("Timezone: ${user.timeZoneIana}")
    }
    is ApiResult.Failure -> // Handle errors
}
```

## 🎨 Code Quality

- ✅ Follows project coding guidelines
- ✅ Material 3 compatible
- ✅ Proper error handling with EitherNet
- ✅ Comprehensive documentation
- ✅ All code formatted with ktlint

## 📚 API Reference

Implements endpoint from [TRMNL API Documentation](https://usetrmnl.com/api-docs):
- **Endpoint**: `GET /me`
- **Auth**: Bearer token required
- **Response**: User profile information