### PR TITLE
Fix navigation: Prevent back navigation from device list to onboarding screens

### DIFF
--- a/app/src/main/java/ink/trmnl/android/buddy/ui/accesstoken/AccessTokenScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/accesstoken/AccessTokenScreen.kt
@@ -122,8 +122,8 @@ class AccessTokenPresenter
                                         // Mark onboarding as completed
                                         userPreferencesRepository.setOnboardingCompleted()
 
-                                        // Navigate to devices list screen
-                                        navigator.goTo(TrmnlDevicesScreen)
+                                        // Navigate to devices list screen (resetRoot to prevent back navigation)
+                                        navigator.resetRoot(TrmnlDevicesScreen)
                                     } catch (e: Exception) {
                                         errorMessage = "Failed to save token: ${e.message}"
                                     } finally {

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/welcome/WelcomeScreen.kt
@@ -83,8 +83,8 @@ class WelcomePresenter
                         if (userPreferences?.apiToken.isNullOrBlank()) {
                             navigator.goTo(AccessTokenScreen)
                         } else {
-                            // Navigate to devices list screen
-                            navigator.goTo(TrmnlDevicesScreen)
+                            // Navigate to devices list screen (resetRoot to prevent back navigation)
+                            navigator.resetRoot(TrmnlDevicesScreen)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
Prevents users from navigating back to the Welcome or API Key input screens once they reach the device list screen by using `resetRoot()` instead of `goTo()`.

## Changes
- **AccessTokenScreen**: Changed `navigator.goTo(TrmnlDevicesScreen)` to `navigator.resetRoot(TrmnlDevicesScreen)` after successfully saving API token
- **WelcomeScreen**: Changed `navigator.goTo(TrmnlDevicesScreen)` to `navigator.resetRoot(TrmnlDevicesScreen)` when user already has an API token

## Why
- Using `resetRoot()` clears the navigation back stack and sets the device list as the new root screen
- Prevents users from accidentally going back to onboarding/setup screens via the back button
- Improves UX by treating the device list as the main authenticated screen (similar to how most apps prevent going back to login after authentication)
- Follows the same pattern already used in logout functionality

## Testing
- ✅ All existing tests pass
- ✅ Code formatted with Kotlinter
- Manually tested navigation flow (recommended):
  1. Fresh install → Welcome → Enter API key → Device list (back button should exit app, not go to API key screen)
  2. With saved token → Welcome → Device list (back button should exit app, not go to Welcome screen)

## References
- Uses Circuit's [`resetRoot()`](https://slackhq.github.io/circuit/navigation/) API for clearing navigation stack
- Follows project pattern established in `UserAccountScreen` logout flow