### PR TITLE
Add device screen preview feature using /display/current API

### DIFF
--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
@@ -1,11 +1,8 @@
 package ink.trmnl.android.buddy.ui.devices
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -426,16 +423,8 @@ private fun DeviceCard(
     onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var isPreviewExpanded by remember { mutableStateOf(false) }
-
     Card(
-        onClick = {
-            if (hasToken && previewImageUrl != null) {
-                isPreviewExpanded = !isPreviewExpanded
-            } else {
-                onClick()
-            }
-        },
+        onClick = onClick,
         modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
     ) {
@@ -607,19 +596,8 @@ private fun DeviceCard(
         // Display preview image if available
         if (hasToken && previewImageUrl != null) {
             AnimatedVisibility(
-                visible = isPreviewExpanded,
-                enter =
-                    fadeIn(animationSpec = tween(300)) +
-                        slideInVertically(
-                            animationSpec = tween(300),
-                            initialOffsetY = { -it / 2 },
-                        ),
-                exit =
-                    fadeOut(animationSpec = tween(300)) +
-                        slideOutVertically(
-                            animationSpec = tween(300),
-                            targetOffsetY = { -it / 2 },
-                        ),
+                visible = true,
+                enter = fadeIn() + slideInVertically(),
             ) {
                 SubcomposeAsyncImage(
                     model = previewImageUrl,


### PR DESCRIPTION
## Summary
Adds a device screen preview feature that displays the current content shown on TRMNL e-ink displays when a device token is configured.

## Changes
- **API Integration**: Uses existing `/display/current` endpoint to fetch preview images
- **Async Loading**: Implements Coil 3 for efficient image loading with proper states
- **UI/UX**:
  - Preview images shown in device cards, below the device info
  - Smooth reveal with `AnimatedVisibility` (fade + slide animations)
  - Loading indicator shown while image fetches
  - Correct TRMNL device aspect ratio (800x480)
  - Only displays for devices with configured tokens
- **Error Handling**: Silently fails if preview unavailable (no error shown to user)

## Technical Details
- Added `devicePreviews: Map<String, String?>` to screen state
- New `loadDevicePreviews()` function fetches images for all devices with tokens
- Uses `SubcomposeAsyncImage` from Coil 3 for loading states
- Preview loading happens automatically after device list and tokens are loaded
- Material 3 compliant with theme-aware colors

## UI Preview
When a device has a configured token (`hasToken = true`):
1. Device info displays as before
2. Below that, the current screen preview loads with a spinner
3. Image fades/slides in smoothly when loaded
4. If image fails to load, nothing is shown (graceful degradation)

## Testing
- ✅ All existing tests pass
- ✅ Code formatted with Kotlinter
- Manual testing recommended:
  1. View device list with configured device tokens
  2. Verify preview images load and display correctly
  3. Check loading states and animations
  4. Verify aspect ratio matches device (800x480)

## Dependencies
- Uses existing Coil 3 dependency (already in project)
- No new dependencies added

## Benefits
- Users can see what's currently on their devices without leaving the app
- Improves visibility into device status
- Helpful for troubleshooting display issues
- Enhances overall user experience