### PR TITLE
Add TRMNL brand color and apply to Welcome screen logo

### DIFF
--- a/app/src/main/java/ink/trmnl/android/buddy/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/welcome/WelcomeScreen.kt
@@ -17,7 +17,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -125,7 +127,7 @@ fun WelcomeContent(
                     painter = painterResource(id = R.drawable.trmnl_logo_plain),
                     contentDescription = "TRMNL Buddy Logo",
                     modifier = Modifier.size(120.dp),
-                    colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary),
+                    colorFilter = ColorFilter.tint(Color(colorResource(id = R.color.trmnl_orange).value)),
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,7 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    
+    <!-- TRMNL Brand Color -->
+    <color name="trmnl_orange">#F8654B</color>
 </resources>


### PR DESCRIPTION
## Summary
Adds the official TRMNL brand color (`#F8654B`) as a color resource and applies it to the logo in the Welcome screen to ensure brand consistency across all themes.

## Changes
- **colors.xml**: Added `trmnl_orange` color resource with value `#F8654B`
- **WelcomeScreen.kt**: 
  - Updated logo `ColorFilter.tint()` to use `trmnl_orange` color resource
  - Replaced `MaterialTheme.colorScheme.primary` with branded color
  - Added necessary imports (`Color`, `colorResource`)

## Why
- **Brand Consistency**: Logo should always display in the official TRMNL brand color
- **Theme Independence**: Color won't change with Material You dynamic theming
- **Centralized**: Color defined in resources makes it reusable throughout the app
- **Design Spec Compliance**: Ensures logo matches TRMNL's official branding

## Before
- Logo color: Changes with `MaterialTheme.colorScheme.primary` (theme-dependent)
- Can appear in different colors based on user's wallpaper/theme

## After
- Logo color: Always TRMNL orange (`#F8654B`)
- Consistent brand identity regardless of theme

## Testing
- ✅ All tests pass
- ✅ Code formatted with Kotlinter
- ✅ Debug APK builds successfully
- Manual testing recommended:
  1. View Welcome screen
  2. Verify logo displays in TRMNL orange color
  3. Test in both light and dark themes
  4. Confirm color remains constant

## Resources
- Color resource: `R.color.trmnl_orange`
- Can be reused in other UI elements if needed for brand consistency