### PR TITLE
Add smooth animations to battery and WiFi progress indicators

### DIFF
--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
@@ -2,6 +2,8 @@ package ink.trmnl.android.buddy.ui.devices
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.clickable
@@ -466,6 +468,26 @@ private fun DeviceCard(
     // Invert colors in dark mode for better visibility of e-ink display images
     val colorFilter = rememberEInkColorFilter()
 
+    // Track if this is the first composition to trigger animation
+    var isInitialized by remember { mutableStateOf(false) }
+
+    // Animate progress indicators from 0 to actual value on first load
+    val batteryProgress by animateFloatAsState(
+        targetValue = if (isInitialized) (device.percentCharged / 100).toFloat() else 0f,
+        animationSpec = tween(durationMillis = 800, delayMillis = 100),
+        label = "battery_progress",
+    )
+    val wifiProgress by animateFloatAsState(
+        targetValue = if (isInitialized) (device.wifiStrength / 100).toFloat() else 0f,
+        animationSpec = tween(durationMillis = 800, delayMillis = 200),
+        label = "wifi_progress",
+    )
+
+    // Trigger animation on first composition
+    LaunchedEffect(Unit) {
+        isInitialized = true
+    }
+
     Card(
         onClick = onClick,
         modifier = modifier.fillMaxWidth(),
@@ -567,7 +589,7 @@ private fun DeviceCard(
                             )
                         }
                         LinearProgressIndicator(
-                            progress = { (device.percentCharged / 100).toFloat() },
+                            progress = { batteryProgress },
                             modifier =
                                 Modifier
                                     .fillMaxWidth()
@@ -605,7 +627,7 @@ private fun DeviceCard(
                             )
                         }
                         LinearProgressIndicator(
-                            progress = { (device.wifiStrength / 100).toFloat() },
+                            progress = { wifiProgress },
                             modifier =
                                 Modifier
                                     .fillMaxWidth()


### PR DESCRIPTION
## Summary
Adds smooth animations to battery and WiFi signal progress indicators in the device list, creating a polished visual experience when device cards first appear.

## Changes
- **Animated Progress Indicators**: Both battery and WiFi progress bars now animate from 0% to their actual values
- **Staggered Timing**: 
  - Battery animation: 800ms duration with 100ms delay
  - WiFi animation: 800ms duration with 200ms delay
  - Creates a pleasant cascading effect
- **State Management**: Uses `remember` and `LaunchedEffect` to track first composition and trigger animations

## Technical Implementation
```kotlin
// Track initialization state
var isInitialized by remember { mutableStateOf(false) }

// Animate from 0 to actual value
val batteryProgress by animateFloatAsState(
    targetValue = if (isInitialized) (device.percentCharged / 100).toFloat() else 0f,
    animationSpec = tween(durationMillis = 800, delayMillis = 100),
    label = "battery_progress",
)

// Trigger animation after first composition
LaunchedEffect(Unit) {
    isInitialized = true
}
```

## Visual Effect
When a device card appears in the list:
1. Battery progress bar smoothly fills from 0% → actual percentage (starts after 100ms)
2. WiFi progress bar smoothly fills from 0% → actual percentage (starts after 200ms)
3. Both animations complete in 800ms with a staggered start for visual polish

## Benefits
- ✨ **Enhanced UX**: Smooth, professional animations make the app feel more polished
- 👁️ **Visual Feedback**: Users can see the progress values "fill up" rather than appearing instantly
- 🎯 **Attention Guide**: Staggered animations naturally draw attention to device metrics
- 🎨 **Material Design**: Follows Material Design animation principles

## Testing
- ✅ All existing tests pass
- ✅ Code formatted with Kotlinter
- ✅ No breaking changes
- Manual testing recommended:
  1. Open device list screen
  2. Observe battery and WiFi indicators animating smoothly
  3. Verify staggered timing (WiFi starts slightly after battery)
  4. Check animation in both light and dark themes

## Performance
- Minimal performance impact (only animates on first composition per card)
- Uses Compose's optimized `animateFloatAsState` 
- Animations are GPU-accelerated