### PR TITLE
Apply device ID obfuscation to DeviceTokenScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Pull-to-refresh functionality on devices list screen using Material 3 PullToRefreshBox
-- Devices are now cached on initial load, preventing unnecessary API calls on every screen visit
-
 ### Security
 - Extended device ID obfuscation to Device API Key management screen for consistent PII protection
 


### PR DESCRIPTION
## Overview
Extends device ID obfuscation to the Device API Key management screen for consistent privacy protection across the app.

## Changes
- Added `obfuscateDeviceId()` helper function to `DeviceTokenScreen.kt`
- Device friendly IDs now display in obfuscated format: `A•••23` (showing first character and last 2 characters)
- Consistent privacy treatment across both device list and device token screens

## Security
- Protects PII (Personally Identifiable Information) by obfuscating device IDs
- Uses bullet character (•) for better visual alignment
- Same obfuscation pattern as used in device list screen

## Testing
- ✅ Code formatted with `./gradlew formatKotlin`
- ✅ All tests passing with `./gradlew test`
- ✅ Obfuscation function matches implementation in `TrmnlDevicesScreen`

## Related
- Follows privacy improvements from PR #18
- Maintains consistency with MAC address obfuscation pattern

## Changelog
Updated `CHANGELOG.md` with security improvement in `[Unreleased]` section.

---
**Note**: This PR originally included pull-to-refresh functionality, but those changes have been reverted as they were not working correctly. Pull-to-refresh will be re-implemented in a future PR.