### PR TITLE
Add privacy toggle for device IDs and MAC addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Privacy toggle button in TRMNL Devices screen top app bar
+  - Allows users to show/hide device IDs and MAC addresses
+  - Privacy is enabled by default (device IDs and MAC addresses are obfuscated)
+  - Toggle state is preserved during screen navigation
+
 ## [1.0.1] - 2025-10-03
 
 ### Added


### PR DESCRIPTION
## Summary

This PR adds a privacy toggle button to the TRMNL Devices screen, allowing users to show/hide sensitive device information (Device IDs and MAC addresses) with a single tap.

## Changes

### Added
- **Privacy toggle button** in the top app bar next to the account button
  - Uses Material `password_2` icon when privacy is enabled
  - Uses `password_2_off` icon when privacy is disabled
  - Privacy is **enabled by default** (device IDs and MAC addresses are obfuscated)
  - Toggle state persists during screen navigation using `rememberRetained`

### Implementation Details
- Added `isPrivacyEnabled: Boolean` to `TrmnlDevicesScreen.State` (default: `true`)
- Added `TogglePrivacy` event to handle toggle action
- Updated `DeviceCard` component to conditionally apply obfuscation based on privacy state
- Device ID obfuscation: `"ABC123"` → `"A•••23"`
- MAC address obfuscation: `"AB:CD:EF:12:34:56"` → `"AB:••:••:••:••:56"`

### Updated Files
- `app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt`
- `CHANGELOG.md` (following Keep a Changelog format)

## Testing

- ✅ Code formatted with `./gradlew formatKotlin`
- ✅ All tests pass with `./gradlew test`
- ✅ Material 3 compliant with theme-aware components
- ✅ Works in both light and dark themes

## Screenshots

The privacy toggle button appears in the top app bar:
- 🔒 Privacy enabled (default): Shows obfuscated values
- 🔓 Privacy disabled: Shows full device ID and MAC address

## Checklist

- [x] Code follows project style guidelines (Kotlin conventions)
- [x] Code formatted with Kotlinter
- [x] All tests pass
- [x] CHANGELOG.md updated with changes
- [x] Material 3 components used throughout
- [x] No hardcoded colors (all theme-aware)
- [x] State properly managed with `rememberRetained`