### PR TITLE
Add Reset Token button for 401 unauthorized errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- "Reset Token" button on unauthorized (401) error state
+  - Appears when API token is invalid or expired
+  - Clears stored API token from preferences
+  - Navigates user back to Access Token screen to re-enter credentials
+
 ## [1.0.2] - 2025-10-03
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes #25

This PR adds a "Reset Token" button to the error screen when users encounter a 401 Unauthorized error. This provides a clear and user-friendly way to recover from expired or invalid API tokens.

## Changes

### Added
- **Reset Token Button**: Appears on error screen when API returns 401 Unauthorized
  - Uses `OutlinedButton` style for appropriate visual hierarchy
  - Clears API token from DataStore preferences
  - Navigates user to Access Token screen with `resetRoot()` to clear navigation stack
  
### Enhanced Error Handling
- Added `isUnauthorized` state flag to distinguish 401 errors from other errors
- Updated `loadDevices()` to return both error message and unauthorized status
- Modified error callbacks throughout the presenter to handle the boolean flag

### UI/UX Improvements
- Users now have a one-tap solution to reset their token when unauthorized
- Navigation stack is properly reset, preventing back navigation issues
- Clear visual indication that token reset is needed

## Implementation Details

**State Changes:**
```kotlin
data class State(
    // ... existing fields
    val isUnauthorized: Boolean = false,  // NEW
    // ...
)
```

**New Event:**
```kotlin
sealed class Event : CircuitUiEvent {
    // ... existing events
    data object ResetToken : Event()  // NEW
}
```

**Error State UI:**
```kotlin
if (state.isUnauthorized) {
    OutlinedButton(
        onClick = { state.eventSink(Event.ResetToken) }
    ) {
        Text("Reset Token")
    }
}
```

## User Flow

1. User's API token becomes invalid/expired
2. App attempts to fetch devices → receives 401 Unauthorized
3. Error screen displays with:
   - ❌ "Error" headline
   - 📝 "Unauthorized. Please check your API token." message
   - 🔄 **"Reset Token" button** (outlined style)
4. User taps "Reset Token"
5. API token is cleared from preferences
6. User is navigated to Access Token screen
7. User enters new valid token
8. Upon saving, navigates back to devices screen

## Testing

- ✅ Code formatted with `./gradlew formatKotlin`
- ✅ All tests pass with `./gradlew test`
- ✅ Material 3 compliant UI components
- ✅ Theme-aware design (works in light and dark modes)
- ✅ CHANGELOG.md updated

## Screenshots

The Reset Token button appears centered below the error message when a 401 error occurs:

```
┌──────────────────────────┐
│                          │
│      Error               │
│                          │
│  Unauthorized. Please    │
│  check your API token.   │
│                          │
│  ┌─────────────────┐    │
│  │  Reset Token    │    │
│  └─────────────────┘    │
│                          │
└──────────────────────────┘
```

## Related Issues

Closes #25