### PR TITLE
Add device token validation and update format guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Clears stored API token from preferences
   - Navigates user back to Access Token screen to re-enter credentials
 
+### Changed
+- Updated Device API Key format guide to reflect actual token format
+  - Updated format description: "20+ character hexadecimal string (e.g., 1a2b3c4d5e6f7g8h9i0j...)"
+  - Updated placeholder text to show generic hexadecimal pattern
+  - Added validation for minimum token length of 20 characters
+
 ## [1.0.2] - 2025-10-03
 
 ### Added

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicetoken/DeviceTokenScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicetoken/DeviceTokenScreen.kt
@@ -130,8 +130,13 @@ class DeviceTokenPresenter
                     }
 
                     DeviceTokenScreen.Event.SaveToken -> {
-                        if (tokenInput.isBlank()) {
+                        val trimmedToken = tokenInput.trim()
+                        if (trimmedToken.isBlank()) {
                             errorMessage = "Token cannot be empty"
+                            return@State
+                        }
+                        if (trimmedToken.length < 20) {
+                            errorMessage = "Token must be at least 20 characters long"
                             return@State
                         }
 
@@ -139,7 +144,7 @@ class DeviceTokenPresenter
                         errorMessage = null
                         coroutineScope.launch {
                             try {
-                                deviceTokenRepository.saveDeviceToken(screen.deviceFriendlyId, tokenInput.trim())
+                                deviceTokenRepository.saveDeviceToken(screen.deviceFriendlyId, trimmedToken)
                                 // Navigate back to devices list
                                 navigator.pop()
                             } catch (e: Exception) {
@@ -279,7 +284,7 @@ fun DeviceTokenContent(
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     Text(
-                        "Format: abc-123",
+                        "Format: 20+ character hexadecimal string (e.g., 1a2b3c4d5e6f7g8h9i0j...)",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontWeight = FontWeight.Medium,
@@ -292,7 +297,7 @@ fun DeviceTokenContent(
                 value = state.tokenInput,
                 onValueChange = { state.eventSink(DeviceTokenScreen.Event.TokenChanged(it)) },
                 label = { Text("Device API Key") },
-                placeholder = { Text("abc-123") },
+                placeholder = { Text("1a2b3c4d5e6f7g8h9i0j...") },
                 modifier = Modifier.fillMaxWidth(),
                 enabled = !state.isSaving,
                 isError = state.errorMessage != null,


### PR DESCRIPTION
## Summary

This PR improves the device token input experience by adding validation and updating the format guidance to match actual TRMNL device API key format.

## Changes

### Updated Format Guide
- Changed format description from `"abc-123"` to `"20+ character hexadecimal string (e.g., 1a2b3c4d5e6f7g8h9i0j...)"`
- Updated placeholder text to show a generic hexadecimal pattern example
- Provides clearer guidance to users about what a valid device token looks like

### Added Validation
- Added minimum length validation requiring at least 20 characters
- Displays helpful error message: "Token must be at least 20 characters long"
- Validates after trimming whitespace to prevent accidental spaces

### Files Modified
- `app/src/main/java/ink/trmnl/android/buddy/ui/devicetoken/DeviceTokenScreen.kt`
  - Updated format description text
  - Updated placeholder text in `OutlinedTextField`
  - Added length validation in `SaveToken` event handler
- `CHANGELOG.md`
  - Documented changes in `[Unreleased]` section under `### Changed`

## User Flow

**Before:**
1. User sees vague format `"abc-123"` 
2. No validation on token length
3. Could save very short/invalid tokens

**After:**
1. User sees clear format: `"20+ character hexadecimal string (e.g., 1a2b3c4d5e6f7g8h9i0j...)"`
2. Placeholder shows realistic example
3. Validation prevents saving tokens shorter than 20 characters
4. Clear error message guides user to provide valid token

## Testing

- [x] Code formatted with `./gradlew formatKotlin`
- [x] Validation works for empty input
- [x] Validation works for tokens < 20 characters
- [x] Valid tokens (≥20 characters) save successfully
- [x] Error messages display correctly
- [x] CHANGELOG.md updated

## Screenshots

The format guide now shows:
```
Format: 20+ character hexadecimal string (e.g., 1a2b3c4d5e6f7g8h9i0j...)
```

Placeholder shows: `1a2b3c4d5e6f7g8h9i0j...`

Error validation prevents short tokens with message: "Token must be at least 20 characters long"