### PR TITLE
chore: Bump version to 1.0.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "ink.trmnl.android.buddy"
         minSdk = 28
         targetSdk = 36
-        versionCode = 5
-        versionName = "1.0.4"
+        versionCode = 6
+        versionName = "1.0.5"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Version Bump to 1.0.5

This PR bumps the version number in preparation for the next release.

### Changes
- Updated `versionCode` from 5 to 6
- Updated `versionName` from "1.0.4" to "1.0.5"

This is a preparation step for the upcoming 1.0.5 release. The actual release will be created once we have features/fixes to include.