### PR TITLE
refactor: Centralize SDK versions and fix deprecated kotlinOptions

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 
 android {
     namespace = "ink.trmnl.android.buddy.api"
-    compileSdk = 35
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
-        minSdk = 26
+        minSdk = libs.versions.minSdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
@@ -28,8 +28,12 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
+}
+
+kotlin {
+    // See https://kotlinlang.org/docs/gradle-compiler-options.html
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
 
 android {
     namespace = "ink.trmnl.android.buddy"
-    compileSdk = 36
+    compileSdk = libs.versions.compileSdk.get().toInt()
 
     defaultConfig {
         applicationId = "ink.trmnl.android.buddy"
         minSdk = 28
-        targetSdk = 36
+        targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 6
         versionName = "1.0.5"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,9 @@
 [versions]
+# Android SDK versions
+compileSdk = "36"
+minSdk = "26"
+targetSdk = "36"
+
 activityCompose = "1.11.0"
 # https://developer.android.com/build/releases/gradle-plugin
 agp = "8.12.1"


### PR DESCRIPTION
- Add compileSdk, minSdk, and targetSdk to libs.versions.toml
- Update app/build.gradle.kts to use centralized SDK versions
- Update api/build.gradle.kts to use centralized SDK versions
- Replace deprecated kotlinOptions {} with kotlin { compilerOptions {} } in api module
- Fix deprecation warning for jvmTarget configuration
- All modules now reference SDK versions from a single source of truth