### PR TITLE
Release 1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6] - 2025-10-20
+
 ### Added
 - **App Information Display**: Version and build type now shown in Settings screen
   - Displays current app version from BuildConfig (e.g., "1.0.5")
@@ -231,7 +233,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.5...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.6...HEAD
+[1.0.6]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.5...1.0.6
 [1.0.5]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.3...1.0.4
 [1.0.3]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.2...1.0.3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "ink.trmnl.android.buddy"
         minSdk = 28
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 6
-        versionName = "1.0.5"
+        versionCode = 7
+        versionName = "1.0.6"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.0.6

This release includes several major features and improvements to the TRMNL Android Buddy app.

### Highlights

**🎨 Settings Screen Enhancements**
- App information display (version and build type)
- GitHub project link for issue reporting
- Account access button moved from Devices to Settings screen

**🔋 Battery Management Features**
- Manual battery recording button on Device Detail screen
- Battery history chart enhancements with data point dots
- Horizontal scrolling support for better chart readability
- Device Detail screen with battery trajectory visualization

**🔧 CI/CD & Build Improvements**
- GitHub Actions release workflows for automated builds
- CI/CD release signing configuration
- Enhanced keystore documentation

**⚙️ Settings & Privacy**
- New Settings screen with battery tracking toggle
- Battery tracking opt-out capability
- Device Detail screen shows when tracking is disabled

**📊 Data & Database**
- Room database integration for battery history
- Automatic weekly battery data collection
- Vico chart library integration for visualizations

### Changes
- Updated `versionCode` from 6 to 7
- Updated `versionName` from "1.0.5" to "1.0.6"
- Moved account button from TRMNL Devices screen to Settings screen
- Release builds now use separate signing configuration

---

**Full changelog**: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.5...1.0.6