### PR TITLE
Fix: Release keystore path resolution in GitHub Actions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
         create("release") {
             // For CI/CD: Use keystore from environment variables (GitHub Actions)
             // For local builds: Fall back to debug keystore
-            val keystoreFile = System.getenv("KEYSTORE_FILE")?.let { file(it) }
+            val keystoreFile = System.getenv("KEYSTORE_FILE")?.let { rootProject.file(it) }
                 ?: file("../keystore/debug.keystore")
             val keystorePassword = System.getenv("KEYSTORE_PASSWORD") ?: "android"
             val keyAliasValue = System.getenv("KEY_ALIAS") ?: "androiddebugkey"


### PR DESCRIPTION
## Problem

The `test-keystore-apk-signing.yml` workflow was failing with the following error:

```
Keystore file '/home/runner/work/trmnl-android-buddy/trmnl-android-buddy/app/keystore/trmnl-android-buddy-release.keystore' not found for signing config 'release'.
```

**Root Cause**: The `KEYSTORE_FILE` environment variable path was being resolved relative to the `app` module directory instead of the project root directory.

- **Workflow decodes keystore to**: `keystore/trmnl-android-buddy-release.keystore` (project root)
- **Build was looking for**: `app/keystore/trmnl-android-buddy-release.keystore` (incorrect)

## Solution

Changed `file(it)` to `rootProject.file(it)` in the release signing configuration in `app/build.gradle.kts`.

```kotlin
val keystoreFile = System.getenv("KEYSTORE_FILE")?.let { rootProject.file(it) }
    ?: file("../keystore/debug.keystore")
```

This ensures the `KEYSTORE_FILE` path is resolved relative to the project root, matching where the GitHub Actions workflow decodes the keystore.

## Testing

After this fix, the workflow should:
1. ✅ Successfully locate the keystore at the correct path
2. ✅ Build the release APK with production signing
3. ✅ Complete without errors

## Related

- Fixes the issue preventing automated release builds in GitHub Actions
- Related to setup documentation in `RELEASE_SETUP.md`
- Affects workflows: `android-release.yml` and `test-keystore-apk-signing.yml`