### PR TITLE
feat: Add AAB build to release workflow for Play Store distribution

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,9 +1,10 @@
 name: Android Release Build
 
-# Workflow that builds release APK for:
+# Workflow that builds release APK and AAB for:
 # 1. Snapshot builds: Each time code changes on main branch
-# 2. Release builds: When a GitHub release is published (automatically attaches APK to release)
+# 2. Release builds: When a GitHub release is published (automatically attaches APK and AAB to release)
 # This allows developers and testers to easily download the latest release APK.
+# AAB (Android App Bundle) is provided for Google Play Store distribution.
 #
 # See:
 # - https://github.com/hossain-khan/trmnl-android-buddy/tree/main/keystore
@@ -51,8 +52,8 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > keystore/trmnl-android-buddy-release.keystore
 
-      - name: Build Release APK
-        run: ./gradlew assembleRelease --parallel --daemon
+      - name: Build Release APK and AAB
+        run: ./gradlew assembleRelease bundleRelease --parallel --daemon
         env:
           KEYSTORE_FILE: keystore/trmnl-android-buddy-release.keystore
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -65,27 +66,35 @@ jobs:
           echo "VERSION=$VERSION_NAME" >> $GITHUB_OUTPUT
           echo "App version name extracted: $VERSION_NAME"
 
-      - name: Rename APK
+      - name: Rename APK and AAB
         run: |
           mkdir -p artifact
           cp app/build/outputs/apk/release/app-release.apk artifact/trmnl-android-buddy-v${{ steps.version.outputs.VERSION }}.apk
+          cp app/build/outputs/bundle/release/app-release.aab artifact/trmnl-android-buddy-v${{ steps.version.outputs.VERSION }}.aab
 
       - name: Upload Release APK
         uses: actions/upload-artifact@v4
         with:
-          name: trmnl-android-buddy-app
+          name: trmnl-android-buddy-apk
           path: artifact/trmnl-android-buddy-v${{ steps.version.outputs.VERSION }}.apk
           # Use maximum allowed retention period
           # https://github.com/actions/upload-artifact?tab=readme-ov-file#retention-period
           retention-days: 30
 
-      # If this is running due to a GitHub release, attach the APK to the release
-      - name: Attach APK to GitHub Release
+      - name: Upload Release AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: trmnl-android-buddy-aab
+          path: artifact/trmnl-android-buddy-v${{ steps.version.outputs.VERSION }}.aab
+          retention-days: 30
+
+      # If this is running due to a GitHub release, attach the APK and AAB to the release
+      - name: Attach APK and AAB to GitHub Release
         if: github.event_name == 'release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Attaching APK to GitHub release..."
+          echo "Attaching APK and AAB to GitHub release..."
           
           # Get release information
           RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
@@ -121,5 +130,30 @@ jobs:
           else
             echo "❌ Failed to upload APK (HTTP $HTTP_CODE)"
             cat upload_response.json
+            exit 1
+          fi
+          
+          # Upload AAB to the release
+          AAB_FILE="artifact/trmnl-android-buddy-v${{ steps.version.outputs.VERSION }}.aab"
+          AAB_NAME="trmnl-android-buddy-v${{ steps.version.outputs.VERSION }}.aab"
+          
+          echo "Uploading $AAB_NAME to release..."
+          
+          UPLOAD_RESPONSE=$(curl -s -w "%{http_code}" -o upload_response_aab.json \
+            -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @"$AAB_FILE" \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/$RELEASE_ID/assets?name=$AAB_NAME")
+          
+          HTTP_CODE="${UPLOAD_RESPONSE: -3}"
+          
+          if [ "$HTTP_CODE" = "201" ]; then
+            echo "✅ Successfully attached AAB to GitHub release"
+            DOWNLOAD_URL=$(jq -r .browser_download_url upload_response_aab.json)
+            echo "AAB download URL: $DOWNLOAD_URL"
+          else
+            echo "❌ Failed to upload AAB (HTTP $HTTP_CODE)"
+            cat upload_response_aab.json
             exit 1
           fi


### PR DESCRIPTION
## Overview

This PR enhances the Android release workflow to build and distribute both **APK** and **AAB** (Android App Bundle) formats.

## Changes

### Build Process
- ✅ Now runs both `assembleRelease` and `bundleRelease` in parallel
- ✅ Both APK and AAB are built with the same signing configuration

### Artifact Management
- ✅ Creates two separate artifacts:
  - `trmnl-android-buddy-apk` - Contains APK file
  - `trmnl-android-buddy-aab` - Contains AAB file
- ✅ Both files properly named with version: `trmnl-android-buddy-v{VERSION}.apk/aab`
- ✅ 30-day retention for both artifacts

### GitHub Release Integration
- ✅ Both APK and AAB are automatically attached to GitHub releases
- ✅ Separate upload logic for each format with error handling
- ✅ Success confirmation with download URLs

## File Locations

After build:
- **APK**: `app/build/outputs/apk/release/app-release.apk` → `artifact/trmnl-android-buddy-v{VERSION}.apk`
- **AAB**: `app/build/outputs/bundle/release/app-release.aab` → `artifact/trmnl-android-buddy-v{VERSION}.aab`

## Use Cases

### APK (Android Package)
- Direct installation on devices
- Sideloading for testing
- Distribution outside Google Play Store
- Alternative app stores

### AAB (Android App Bundle)
- **Google Play Store distribution** (required format)
- Smaller download sizes for end users (optimized per device)
- Better resource optimization
- Future-proof for Play Store requirements

## Benefits

1. **Developer-friendly**: APK available for quick testing and sideloading
2. **Play Store ready**: AAB available for official distribution
3. **Single workflow**: Both formats built together efficiently
4. **Consistent naming**: Version-tagged files for easy identification
5. **Release automation**: Both formats automatically attached to GitHub releases

## Testing

To test this workflow:
1. Merge this PR
2. Run the workflow manually from Actions tab, or
3. Create a new release tag to trigger automatic build and attachment

## Related

- Complements PR #77 (keystore path fix)
- Follows conventions in `RELEASE_SETUP.md`
- Uses signing configuration from `app/build.gradle.kts`