### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-10-21
+
+### Added
+- **AAB (Android App Bundle) Distribution**: Release workflow now builds both APK and AAB formats
+  - APK for direct installation and sideloading
+  - AAB for Google Play Store distribution with optimized downloads
+  - Both formats automatically attached to GitHub releases
+  - Separate artifacts with version naming (e.g., `trmnl-android-buddy-v1.1.0.apk` and `.aab`)
+
+### Fixed
+- **Release Keystore Path Resolution**: Fixed GitHub Actions workflow keystore path issue
+  - Changed from module-relative to project-relative path resolution using `rootProject.file()`
+  - Resolves workflow failure where keystore file was not found during automated builds
+  - Ensures proper keystore location for CI/CD release signing
+
 ## [1.0.6] - 2025-10-20
 
 ### Added
@@ -233,7 +248,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.6...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.6...1.1.0
 [1.0.6]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.5...1.0.6
 [1.0.5]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.3...1.0.4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "ink.trmnl.android.buddy"
         minSdk = 28
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 7
-        versionName = "1.0.6"
+        versionCode = 8
+        versionName = "1.1.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.1.0

This release includes important CI/CD improvements and adds support for Google Play Store distribution.

### Highlights

**📦 AAB (Android App Bundle) Support**
- Release workflow now builds both APK and AAB formats
- APK for direct installation and sideloading
- AAB for Google Play Store distribution with optimized downloads
- Both formats automatically attached to GitHub releases
- Properly named artifacts with version numbers

**🔧 CI/CD Fixes**
- Fixed release keystore path resolution in GitHub Actions
- Changed from module-relative to project-relative path using `rootProject.file()`
- Resolves automated build failures where keystore was not found

### Changes
- Updated `versionCode` from 7 to 8
- Updated `versionName` from "1.0.6" to "1.1.0"
- Enhanced `android-release.yml` workflow to build both APK and AAB
- Fixed keystore path resolution in `app/build.gradle.kts`

### Version Bump Rationale
Using 1.1.0 (minor version bump) because:
- ✅ New feature: AAB distribution support (backward compatible)
- ✅ Bug fixes: Keystore path resolution
- ✅ No breaking changes

---

**Full changelog**: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.6...1.1.0