### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-10-21
+
 ### Added
 - **TRMNL "Works With" Badge on Welcome Screen**: Added official TRMNL branding badge
   - Theme-aware badge that automatically switches between light and dark variants
@@ -269,7 +271,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.1.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.6...1.1.0
 [1.0.6]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.5...1.0.6
 [1.0.5]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.4...1.0.5

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,8 +18,8 @@ android {
         applicationId = "ink.trmnl.android.buddy"
         minSdk = 28
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 8
-        versionName = "1.1.0"
+        versionCode = 9
+        versionName = "1.2.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.2.0

This release includes significant branding and typography enhancements with official TRMNL assets.

### What's New in 1.2.0

#### TRMNL "Works With" Badge
- ✅ Added official TRMNL branding badge to welcome screen
- ✅ Theme-aware badge automatically switches between light/dark variants
- ✅ Positioned in bottom right corner (80dp)
- ✅ Includes all official TRMNL brand assets

#### EB Garamond Typography
- ✅ Elegant EB Garamond font for enhanced visual identity
- ✅ Applied to all screen titles via reusable `TrmnlTitle` component
- ✅ Google Fonts downloadable font integration
- ✅ Consistent branding across 8 screens

#### Documentation
- ✅ Comprehensive Google Play Store listing documentation
- ✅ Updated CHANGELOG with all features

### Version Details
- **Version Code**: 9
- **Version Name**: 1.2.0
- **Release Date**: October 21, 2025

### Changelog Summary
See [CHANGELOG.md](https://github.com/hossain-khan/trmnl-android-buddy/blob/release/1.2.0/CHANGELOG.md#120---2025-10-21) for full details.

---

**Ready to merge and tag as 1.2.0**