### PR TITLE
fix: Replace GlobalScope with rememberCoroutineScope for lifecycle-aware coroutines

### DIFF
--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicedetail/DeviceDetailScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicedetail/DeviceDetailScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -146,6 +147,7 @@ class DeviceDetailPresenter
                     ink.trmnl.android.buddy.data.preferences
                         .UserPreferences(),
             )
+            val coroutineScope = rememberCoroutineScope()
 
             // Check if battery has been recorded today
             val hasRecordedToday by remember {
@@ -185,7 +187,7 @@ class DeviceDetailPresenter
                     DeviceDetailScreen.Event.BackClicked -> navigator.pop()
                     is DeviceDetailScreen.Event.PopulateBatteryHistory -> {
                         // Generate simulated battery history data
-                        kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO) {
+                        coroutineScope.launch(Dispatchers.IO) {
                             val currentTime = System.currentTimeMillis()
                             val weeksToGenerate = 12 // Generate 12 weeks of history
                             val currentBattery = screen.currentBattery
@@ -210,13 +212,13 @@ class DeviceDetailPresenter
                     }
                     DeviceDetailScreen.Event.ClearBatteryHistory -> {
                         // Clear all battery history for this device
-                        kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO) {
+                        coroutineScope.launch(Dispatchers.IO) {
                             batteryHistoryRepository.deleteHistoryForDevice(screen.deviceId)
                         }
                     }
                     DeviceDetailScreen.Event.RecordBatteryManually -> {
                         // Record current battery level manually
-                        kotlinx.coroutines.GlobalScope.launch(Dispatchers.IO) {
+                        coroutineScope.launch(Dispatchers.IO) {
                             batteryHistoryRepository.recordBatteryReading(
                                 deviceId = screen.deviceId,
                                 percentCharged = screen.currentBattery,


### PR DESCRIPTION
## 🐛 Problem

The `DeviceDetailPresenter` was using `GlobalScope.launch(Dispatchers.IO)` in 3 places, which violates Jetpack Compose and Circuit best practices.

### Issues with GlobalScope:
- ❌ **Not lifecycle-aware**: Coroutines continue running even after composable is disposed
- ❌ **Memory leaks**: Operations don't get cancelled when screen is destroyed
- ❌ **No automatic cancellation**: Tasks continue even when user navigates away
- ❌ **Against best practices**: Violates Compose and Circuit guidelines

## ✅ Solution

Replaced all `GlobalScope.launch` calls with `rememberCoroutineScope().launch` to ensure proper lifecycle management.

### Changes Made:

1. **Added `rememberCoroutineScope()`** in `DeviceDetailPresenter.present()`
2. **Replaced 3 instances** of `GlobalScope.launch` with `coroutineScope.launch`:
   - `PopulateBatteryHistory` event - Generate simulated battery data
   - `ClearBatteryHistory` event - Clear device history
   - `RecordBatteryManually` event - Manual battery recording
3. **Added missing import**: `androidx.compose.runtime.rememberCoroutineScope`

## 🎯 Benefits

- ✅ **Lifecycle-aware**: Coroutines automatically cancel when composable leaves composition
- ✅ **No memory leaks**: Operations properly cleaned up on navigation
- ✅ **Best practices**: Follows Jetpack Compose coroutine guidelines
- ✅ **Circuit compliant**: Aligns with Circuit architecture patterns

## 🧪 Testing

- ✅ All unit tests passing
- ✅ Code formatted with Kotlinter
- ✅ Build successful

## 📚 Reference

Follows best practices outlined in [Jetpack Compose side-effects documentation](https://developer.android.com/jetpack/compose/side-effects#rememberCoroutineScope)