### PR TITLE
Fix: Add contents:write permission to release workflow

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -23,7 +23,10 @@ on:
 jobs:
   build-release:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write  # Required to upload release assets
+      actions: read    # Required to read workflow artifacts
+      
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Problem

The Android Release workflow was failing with a **403 Forbidden** error when trying to upload APK and AAB files to GitHub releases:

```
❌ Failed to upload APK (HTTP 403)
{"message":"Resource not accessible by integration","request_id":"F454:C95F1:28C87E:2F7836:68F7FB34"}
```

## Root Cause

The `GITHUB_TOKEN` provided by GitHub Actions didn't have sufficient permissions to upload release assets. By default, the token has limited permissions and needs explicit `contents: write` permission to upload files to releases.

## Solution

Added explicit permissions to the workflow job:

```yaml
permissions:
  contents: write  # Required to upload release assets
  actions: read    # Required to read workflow artifacts
```

## Changes

- ✅ **Added `contents: write` permission** - Allows uploading APK/AAB to GitHub releases
- ✅ **Added `actions: read` permission** - Ensures proper access to workflow artifacts
- ✅ **Resolves 403 Forbidden error** - Workflow can now successfully upload release assets

## Testing

This fix addresses the specific error encountered in workflow run: https://github.com/hossain-khan/trmnl-android-buddy/actions/runs/18698177610/job/53320867348

The next release workflow run should successfully:
1. Build APK and AAB files ✅
2. Upload them as workflow artifacts ✅  
3. **Attach them to GitHub releases** ✅ (previously failing)

## Impact

- **No breaking changes** - Only adds permissions
- **Backward compatible** - Doesn't affect existing functionality
- **Security conscious** - Uses minimal required permissions

## References

- [GitHub Actions Permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)
- [GitHub REST API - Release Assets](https://docs.github.com/en/rest/releases/assets)

This fixes the workflow so that both APK and AAB files will be automatically attached to GitHub releases! 🚀