### PR TITLE
[FIXED] Temporarily disable color inversion for #102

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Disabled color inversion for dark mode
+
 ## [1.3.0] - 2025-10-22
 
 ### Changed

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreen.kt
@@ -38,7 +38,6 @@ import ink.trmnl.android.buddy.R
 import ink.trmnl.android.buddy.data.preferences.DeviceTokenRepository
 import ink.trmnl.android.buddy.ui.components.TrmnlTitle
 import ink.trmnl.android.buddy.ui.sharedelements.DevicePreviewImageKey
-import ink.trmnl.android.buddy.ui.utils.rememberEInkColorFilter
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -105,9 +104,6 @@ fun DevicePreviewContent(
     state: DevicePreviewScreen.State,
     modifier: Modifier = Modifier,
 ) {
-    // Invert colors in dark mode for better visibility of e-ink display images
-    val colorFilter = rememberEInkColorFilter()
-
     Scaffold(
         modifier = modifier.fillMaxSize(),
         topBar = {
@@ -153,7 +149,6 @@ fun DevicePreviewContent(
                                 animatedVisibilityScope = requireAnimatedScope(Navigation),
                             ).fillMaxSize(),
                     contentScale = ContentScale.Fit,
-                    colorFilter = colorFilter,
                     loading = {
                         Box(
                             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
@@ -85,7 +85,6 @@ import ink.trmnl.android.buddy.ui.utils.getBatteryColor
 import ink.trmnl.android.buddy.ui.utils.getBatteryIcon
 import ink.trmnl.android.buddy.ui.utils.getWifiColor
 import ink.trmnl.android.buddy.ui.utils.getWifiIcon
-import ink.trmnl.android.buddy.ui.utils.rememberEInkColorFilter
 import ink.trmnl.android.buddy.util.PrivacyUtils
 import ink.trmnl.android.buddy.util.formatRefreshRate
 import ink.trmnl.android.buddy.util.formatRefreshRateExplanation
@@ -652,9 +651,6 @@ private fun DeviceCard(
     eventSink: (TrmnlDevicesScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Invert colors in dark mode for better visibility of e-ink display images
-    val colorFilter = rememberEInkColorFilter()
-
     // Track if this is the first composition to trigger animation
     var isInitialized by remember { mutableStateOf(false) }
 
@@ -962,9 +958,6 @@ private fun DevicePreviewImage(
     eventSink: (TrmnlDevicesScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    // Invert colors in dark mode for better visibility of e-ink display images
-    val colorFilter = rememberEInkColorFilter()
-
     if (hasToken && previewInfo != null) {
         AnimatedVisibility(
             visible = true,
@@ -992,7 +985,6 @@ private fun DevicePreviewImage(
                                 ).fillMaxSize()
                                 .clickable(onClick = onPreviewClick),
                         contentScale = ContentScale.Fit,
-                        colorFilter = colorFilter,
                         loading = {
                             Box(
                                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
Related to #102 

This pull request removes the automatic color inversion for e-ink display images in dark mode, addressing visibility and styling issues. The change affects both the device preview and device card components, ensuring consistent appearance regardless of the system theme.

**Dark mode color inversion removal:**

* Removed the use of `rememberEInkColorFilter` and the associated color inversion logic from `DevicePreviewScreen.kt` and `TrmnlDevicesScreen.kt`, so e-ink display images are no longer inverted in dark mode. [[1]](diffhunk://#diff-f2ffc744e80976ce84141c681f64e6518c83be4572efb87fbb3d370aa564c213L41) [[2]](diffhunk://#diff-f2ffc744e80976ce84141c681f64e6518c83be4572efb87fbb3d370aa564c213L108-L110) [[3]](diffhunk://#diff-f2ffc744e80976ce84141c681f64e6518c83be4572efb87fbb3d370aa564c213L156) [[4]](diffhunk://#diff-219ade256b7ef8db93df5018c742629036ce981abb94657151834192acb1e13aL88) [[5]](diffhunk://#diff-219ade256b7ef8db93df5018c742629036ce981abb94657151834192acb1e13aL655-L657) [[6]](diffhunk://#diff-219ade256b7ef8db93df5018c742629036ce981abb94657151834192acb1e13aL965-L967) [[7]](diffhunk://#diff-219ade256b7ef8db93df5018c742629036ce981abb94657151834192acb1e13aL995)

**Changelog update:**

* Added an entry to the `CHANGELOG.md` under "Fixed" to note that color inversion for dark mode has been disabled.