### PR TITLE
[UPDATE] Moved the image refresh indicator to right top corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Moved the image refresh time indicator to the top-right corner of the device preview
+
 ### Fixed
 - Disabled color inversion for dark mode
 

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
@@ -1007,7 +1007,7 @@ private fun DevicePreviewImage(
                         onInfoClick = { rate ->
                             eventSink(TrmnlDevicesScreen.Event.RefreshRateInfoClicked(rate))
                         },
-                        modifier = Modifier.align(Alignment.TopStart),
+                        modifier = Modifier.align(Alignment.TopEnd),
                     )
                 }
             }
@@ -1032,7 +1032,7 @@ private fun RefreshRateIndicator(
                 .padding(8.dp),
         colors =
             CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.85f),
+                containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.75f),
             ),
         shape = MaterialTheme.shapes.small,
     ) {


### PR DESCRIPTION
This pull request updates the UI for the device preview image by repositioning and visually adjusting the image refresh time indicator. The most important changes are:

**UI Improvements:**

* The image refresh time indicator has been moved from the top-left to the top-right corner of the device preview for better visibility and alignment. [[1]](diffhunk://#diff-219ade256b7ef8db93df5018c742629036ce981abb94657151834192acb1e13aL1010-R1010) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R12)
* The background opacity of the refresh time indicator has been slightly reduced (from 0.85 to 0.75) to make it less visually intrusive.

**Documentation:**

* Updated the `CHANGELOG.md` to reflect the new position of the image refresh time indicator.