### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2025-10-22
+
 ### Changed
 - Moved the image refresh time indicator to the top-right corner of the device preview
 
@@ -287,7 +289,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.3.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.4.0...HEAD
+[1.4.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.0.6...1.1.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
 
         // Google Play app versioning - keep in sync with release notes and changelog
-        versionCode = 10
-        versionName = "1.3.0"
+        versionCode = 11
+        versionName = "1.4.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.4.0

### Changed
- Moved the image refresh time indicator to the top-right corner of the device preview

### Fixed
- Disabled color inversion for dark mode

---

**Release checklist:**
- [x] Version number updated (1.4.0, versionCode 11)
- [x] CHANGELOG.md updated
- [x] Release branch created
- [ ] PR merged to main
- [ ] Tag created and pushed
- [ ] GitHub release created