### PR TITLE
Release 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2025-10-23
+
+### Changed
+- **Dependency Updates**: Upgraded key dependencies to stable releases
+  - Vico chart library upgraded from 2.0.0-alpha.28 to 2.2.1 (stable)
+  - Room database upgraded from 2.7.0-alpha13 to 2.8.3 (stable)
+  - Migrated battery history chart to new Vico 2.x API
+
 ### Added
 - **Privacy Toggle Feedback**: Added snackbar messages when privacy toggle is used in TrmnlDevicesScreen
   - Shows "Personal information hidden for privacy" when privacy is enabled
@@ -340,7 +348,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.5.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.6.0...HEAD
+[1.6.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.5.0...1.6.0
 [1.5.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.4.0...1.5.0
 [1.4.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.3.0...1.4.0
 [1.3.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.2.0...1.3.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         targetSdk = libs.versions.targetSdk.get().toInt()
 
         // Google Play app versioning - keep in sync with release notes and changelog
-        versionCode = 12
-        versionName = "1.5.0"
+        versionCode = 13
+        versionName = "1.6.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.6.0

This release includes dependency updates and UX improvements.

### Changed
- **Dependency Updates**: Upgraded key dependencies to stable releases
  - Vico chart library upgraded from 2.0.0-alpha.28 to 2.2.1 (stable)
  - Room database upgraded from 2.7.0-alpha13 to 2.8.3 (stable)
  - Migrated battery history chart to new Vico 2.x API

### Added
- **Privacy Toggle Feedback**: Added snackbar messages when privacy toggle is used in TrmnlDevicesScreen
  - Shows "Personal information hidden for privacy" when privacy is enabled
  - Shows "Personal information now visible" when privacy is disabled
  - Provides clear feedback about PII visibility state changes

### Fixed
- **DeviceTokenScreen UX**: Added clickable link to TRMNL devices page in Device API Key setup
  - Users can now click "device settings" text to navigate directly to https://usetrmnl.com/devices/
  - Improves user experience for finding device API keys during setup
  - Uses Material 3 LinkAnnotation with theme-aware styling

---

**Version**: 1.6.0 (versionCode: 13)
**Previous**: 1.5.0 (versionCode: 12)

See [CHANGELOG.md](https://github.com/hossain-khan/trmnl-android-buddy/blob/release/1.6.0/CHANGELOG.md) for full details.