### PR TITLE
Release 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2025-10-23
+
 ### Added
 - **DevicePreviewScreen Refresh**: Added refresh button to preview screen to reload current display image
   - New refresh button in top app bar alongside download button
@@ -365,7 +367,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.6.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.7.0...HEAD
+[1.7.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.6.0...1.7.0
 [1.6.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.5.0...1.6.0
 [1.5.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.4.0...1.5.0
 [1.4.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.3.0...1.4.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 13
-        versionName = "1.6.0"
+        versionCode = 14
+        versionName = "1.7.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 1.7.0

This release adds image refresh functionality and improves API request identification.

### Added
- **DevicePreviewScreen Refresh**: Added refresh button to preview screen to reload current display image
  - New refresh button in top app bar alongside download button
  - Calls `/display/current` API to fetch latest device screen image
  - Shows loading indicator while refreshing
  - Displays success/error messages via snackbar
  - Handles HTTP 500 (server error) and 429 (rate limit) with user-friendly messages
  - Updates preview image URL when refresh succeeds

### Changed
- **User Agent**: Implemented dynamic user agent for API requests following industry best practices
  - Format: `TrmnlAndroidBuddy/Version (Android APILevel; DeviceModel) OkHttp/Version`
  - Includes app version from BuildConfig.VERSION_NAME
  - Includes Android API level and device model
  - Includes OkHttp version for better server-side debugging
  - Replaces hardcoded "TrmnlAndroidBuddy/1.0" with dynamic version information

---

**Version**: 1.7.0 (versionCode: 14)
**Previous**: 1.6.0 (versionCode: 13)

See [CHANGELOG.md](https://github.com/hossain-khan/trmnl-android-buddy/blob/release/1.7.0/CHANGELOG.md) for full details.