### PR TITLE
chore: Update copilot instructions to require GitHub MCP tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -474,3 +474,40 @@ suspend fun fetchDevices(): Result<List<Device>> {
 - Don't use PII (Personally Identifiable Information) in code examples or tests
 - **Do NOT create summary markdown files** (like `FEATURE_SUMMARY.md`, `SCREENS_IMPLEMENTATION.md`, etc.) for features or bug fixes
 - Keep documentation in existing files like README.md, CHANGELOG.md, or inline code comments
+
+### GitHub Operations
+
+**ALWAYS use GitHub MCP tools for GitHub operations:**
+
+- **Creating Pull Requests**: Use `mcp_github_create_pull_request` tool
+  - Never use `gh pr create` CLI command
+  - Provide comprehensive PR description with changes, testing, and checklist
+  - Include code examples and screenshots when relevant
+
+- **Reading Pull Requests**: Use `mcp_github_pull_request_read` tool
+  - Get PR details, diff, status, files, reviews, or comments
+  - Never use `gh pr view` or `gh pr diff` CLI commands
+
+- **Reading Issues**: Use `mcp_github_get_issue` tool
+  - Never use `gh issue view` CLI command
+
+- **Creating Issues**: Use `mcp_github_create_issue` tool
+  - Never use `gh issue create` CLI command
+
+- **Searching**: Use MCP search tools for code, issues, PRs, or repositories
+  - `mcp_github_search_code` for code search
+  - `mcp_github_search_issues` for issue search
+  - `mcp_github_search_pull_requests` for PR search
+  - Never use `gh search` CLI commands
+
+**If GitHub MCP tools are not available:**
+- **DO NOT** fall back to `gh` CLI commands
+- Instead, inform the user that GitHub MCP tools are required
+- Ask the user to install the GitHub MCP server
+- Provide setup instructions if needed
+
+**Rationale:**
+- MCP tools provide better structured responses
+- Consistent API-based interaction
+- Better error handling and type safety
+- Avoid shell command parsing issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Copilot Instructions**: Updated GitHub operations guidance for AI assistants
+  - Added requirement to always use GitHub MCP tools instead of `gh` CLI
+  - Specified MCP tools for PRs, issues, and search operations
+  - Added fallback instructions if MCP tools are unavailable
+  - Improved consistency and error handling for GitHub operations
+
 - **Always-Visible Filter Bar in Announcements**: Filter chips now permanently pinned at the top
   - Moved filter chips outside the scrollable LazyColumn to ensure they're always visible
   - Filters are now fixed at the top in a separate Surface layer above the pull-to-refresh list


### PR DESCRIPTION
## Overview
Updates the GitHub Copilot instructions to establish best practices for AI assistants when performing GitHub operations, requiring the use of GitHub MCP tools instead of CLI commands.

## Changes

### 📚 New GitHub Operations Section
Added comprehensive guidance for AI assistants on GitHub interactions:

**Required MCP Tools:**
- `mcp_github_create_pull_request` - For creating PRs (not `gh pr create`)
- `mcp_github_pull_request_read` - For reading PR details (not `gh pr view`)
- `mcp_github_get_issue` - For reading issues (not `gh issue view`)
- `mcp_github_create_issue` - For creating issues (not `gh issue create`)
- `mcp_github_search_*` - For searching code/issues/PRs (not `gh search`)

**Key Guidelines:**
- ✅ **Always use MCP tools** for GitHub operations
- ❌ **Never fall back to `gh` CLI** commands
- 🔧 **If MCP unavailable**: Ask user to install GitHub MCP server instead
- 📋 **Provide setup instructions** when needed

### 🎯 Benefits
- **Better structured responses** from API-based interaction
- **Improved error handling** and type safety
- **Consistent behavior** across all GitHub operations
- **Avoids shell parsing issues** with CLI commands
- **More reliable automation** for PR/issue management

## Documentation Updates
- ✅ Updated `.github/copilot-instructions.md` with new GitHub Operations section
- ✅ Updated `CHANGELOG.md` with documentation changes

## Rationale
This change ensures that AI assistants use the more robust GitHub MCP tools which provide:
1. Structured API responses (vs. parsing CLI text output)
2. Type-safe interactions with GitHub API
3. Better error messages and handling
4. Consistent behavior across different shells/environments
5. Direct API access without shell command overhead

## Testing
- ✅ Documentation changes only (no code changes)
- ✅ CHANGELOG.md follows Keep a Changelog format
- ✅ Copilot instructions clearly specify when to use each tool

## Checklist
- [x] Updated copilot instructions with clear guidelines
- [x] Added rationale for using MCP over CLI
- [x] Specified all relevant MCP tools
- [x] Included fallback instructions if MCP unavailable
- [x] Updated CHANGELOG.md
- [x] No code changes (documentation only)

---

**Note**: This PR itself was created using `mcp_github_create_pull_request` as an example of the new guidelines! 🎉