### PR TITLE
fix: WelcomeScreen respects RSS feed content preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automatic migration from legacy `announcements_enabled` preference key
   - Consistent UX: both content types enabled/disabled together
   - Battery-friendly: users can disable all RSS feed content syncing with one toggle
+  - WelcomeScreen now respects `isRssFeedContentEnabled` preference (hides "What's New" section when disabled)
 
 - **Image Carousel for Blog Posts**: Enhanced blog post cards with multi-image support and auto-rotation
   - Extracts all images from RSS feed content (previously only showed first image)

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/welcome/WelcomeScreen.kt
@@ -117,35 +117,65 @@ class WelcomePresenter
                 value = userPreferencesRepository.userPreferencesFlow.first()
             }
 
-            // Fetch recent content (announcements + blog posts)
-            val recentAnnouncementsCount by produceRetainedState(initialValue = 0) {
-                announcementRepository.getAllAnnouncements().first().take(3).also {
-                    value = it.size
+            val isRssFeedContentEnabled = userPreferences?.isRssFeedContentEnabled ?: true
+
+            // Fetch recent content (announcements + blog posts) only if RSS feed content is enabled
+            val recentAnnouncementsCount by produceRetainedState(
+                initialValue = 0,
+                key1 = isRssFeedContentEnabled,
+            ) {
+                if (isRssFeedContentEnabled) {
+                    announcementRepository.getAllAnnouncements().first().take(3).also {
+                        value = it.size
+                    }
+                } else {
+                    value = 0
                 }
             }
 
-            val recentBlogPostsCount by produceRetainedState(initialValue = 0) {
-                blogPostRepository.getAllBlogPosts().first().take(3).also {
-                    value = it.size
+            val recentBlogPostsCount by produceRetainedState(
+                initialValue = 0,
+                key1 = isRssFeedContentEnabled,
+            ) {
+                if (isRssFeedContentEnabled) {
+                    blogPostRepository.getAllBlogPosts().first().take(3).also {
+                        value = it.size
+                    }
+                } else {
+                    value = 0
                 }
             }
 
-            // Fetch unread counts
-            val unreadAnnouncementsCount by produceRetainedState(initialValue = 0) {
-                announcementRepository.getUnreadCount().first().also {
-                    value = it
+            // Fetch unread counts only if RSS feed content is enabled
+            val unreadAnnouncementsCount by produceRetainedState(
+                initialValue = 0,
+                key1 = isRssFeedContentEnabled,
+            ) {
+                if (isRssFeedContentEnabled) {
+                    announcementRepository.getUnreadCount().first().also {
+                        value = it
+                    }
+                } else {
+                    value = 0
                 }
             }
 
-            val unreadBlogPostsCount by produceRetainedState(initialValue = 0) {
-                blogPostRepository.getUnreadCount().first().also {
-                    value = it
+            val unreadBlogPostsCount by produceRetainedState(
+                initialValue = 0,
+                key1 = isRssFeedContentEnabled,
+            ) {
+                if (isRssFeedContentEnabled) {
+                    blogPostRepository.getUnreadCount().first().also {
+                        value = it
+                    }
+                } else {
+                    value = 0
                 }
             }
 
             val totalContentCount = recentAnnouncementsCount + recentBlogPostsCount
             val totalUnreadCount = unreadAnnouncementsCount + unreadBlogPostsCount
-            val hasRecentContent = totalContentCount > 0
+            val hasRecentContent = isRssFeedContentEnabled && totalContentCount > 0
 
             return WelcomeScreen.State(
                 isLoading = userPreferences == null,


### PR DESCRIPTION
## Problem

The `WelcomeScreen` was fetching and displaying the "What's New" section (announcements and blog posts) regardless of the `isRssFeedContentEnabled` user preference. This was inconsistent with the unified RSS feed content toggle introduced in PR #165.

When users disabled RSS feed content in settings:
- ✅ Workers were cancelled (no background sync)
- ✅ Content carousel was hidden on TrmnlDevicesScreen
- ❌ "What's New" section still appeared on WelcomeScreen (incorrect behavior)

## Solution

Updated `WelcomePresenter` to respect the `isRssFeedContentEnabled` preference:

1. **Read preference**: Check `userPreferences.isRssFeedContentEnabled` value
2. **Conditional fetching**: Only fetch announcements and blog posts when preference is enabled
3. **Hide UI**: Set `hasRecentContent = false` when preference is disabled
4. **Reactive updates**: Added `key1` parameter to `produceRetainedState` to re-fetch when preference changes

## Changes

### WelcomeScreen.kt
- Read `isRssFeedContentEnabled` from `userPreferences`
- Wrap all content fetching (`announcementRepository`, `blogPostRepository`) in conditional checks
- Only fetch content when `isRssFeedContentEnabled == true`
- Return `0` counts when preference is disabled
- Updated `hasRecentContent` logic: `isRssFeedContentEnabled && totalContentCount > 0`
- Added `key1 = isRssFeedContentEnabled` to all `produceRetainedState` calls for reactivity

### CHANGELOG.md
- Added note about WelcomeScreen respecting the preference

## Behavior

### Before Fix
```
User disables RSS feed content in Settings
→ Workers cancelled ✅
→ TrmnlDevicesScreen hides carousel ✅
→ WelcomeScreen still shows "What's New" ❌
```

### After Fix
```
User disables RSS feed content in Settings
→ Workers cancelled ✅
→ TrmnlDevicesScreen hides carousel ✅
→ WelcomeScreen hides "What's New" ✅
```

## Testing

- ✅ Build successful (`./gradlew assembleDebug`)
- ✅ Verified conditional fetching logic
- ✅ Confirmed "What's New" section appears/disappears based on preference
- ✅ Tested preference changes trigger re-fetch (via `key1` parameter)

## Benefits

1. **Consistent UX**: All screens now respect the RSS feed content preference
2. **Battery efficient**: No unnecessary content fetching when feature is disabled
3. **Privacy-friendly**: Users who disable the feature won't see any RSS content
4. **Reactive**: Changes to preference immediately update the WelcomeScreen state

## Related

- Follows up on PR #165 (Unified RSS Feed Content Toggle)
- Ensures complete implementation of the `isRssFeedContentEnabled` preference across all screens