### PR TITLE
Fix Settings Screen Material You Compliance and Missing Notification Permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Changed `Color.Gray.copy(alpha = 0.3f)` to `MaterialTheme.colorScheme.outlineVariant`
   - Dividers now properly adapt to light/dark theme and dynamic color theming
   - Ensures proper contrast ratios and follows Material 3 design guidelines
+- **RSS Feed Content Notifications**: Added missing runtime notification permission check (Android 13+)
+  - "Get notified for new content" toggle now properly requests POST_NOTIFICATIONS permission
+  - Consistent with Low Battery Alerts permission handling
+  - Shows permission denied dialog with settings instructions when permission is not granted
 - Fixed MainActivity to extend FragmentActivity (required by BiometricPrompt API) instead of ComponentActivity
 - Fixed biometric authentication not showing due to incorrect activity type
 


### PR DESCRIPTION
## Summary

This PR fixes two issues found in the Settings Screen:

1. **Material You Compliance**: Replaced hardcoded divider colors with Material 3 theme colors
2. **Missing Notification Permission**: Added runtime permission check for RSS feed content notifications

## Changes

### 1. Material You Compliance Fix

**Issue**: Two `HorizontalDivider` components were using hardcoded `Color.Gray.copy(alpha = 0.3f)` instead of Material 3 theme colors, violating Material You design guidelines.

**Fixed Locations**:
- RssFeedContentSection: Divider between main toggle and notification setting
- LowBatteryNotificationSection: Divider between main toggle and threshold slider

**Changes**:
- ✅ Replaced `Color.Gray.copy(alpha = 0.3f)` with `MaterialTheme.colorScheme.outlineVariant`
- ✅ Removed unused `import androidx.compose.ui.graphics.Color`

**Benefits**:
- Dividers now adapt to light/dark theme automatically
- Supports dynamic color theming (Android 12+) based on wallpaper
- Maintains proper contrast ratios per Material 3 guidelines
- Follows Material You design system

### 2. Missing Notification Permission Check

**Issue**: The "Get notified for new content" toggle was missing runtime notification permission check for Android 13+ (POST_NOTIFICATIONS), while Low Battery Alerts had it properly implemented.

**Changes**:
- ✅ Added `@OptIn(ExperimentalPermissionsApi::class)` to `RssFeedContentSection`
- ✅ Added `rememberPermissionState` for `POST_NOTIFICATIONS` permission
- ✅ Created `handleNotificationToggle()` function to check/request permission
- ✅ Added permission denied dialog with instructions
- ✅ Updated Switch to use permission-aware toggle handler

**Behavior**:
- **Android 13+**: Requests `POST_NOTIFICATIONS` permission when enabling notifications
- **Android 12-**: No permission needed, toggle works immediately
- **Permission denied**: Shows dialog with instructions to grant in device settings
- **Consistent UX**: Now matches Low Battery Alerts permission flow

## Testing

- ✅ Code formatted with `./gradlew formatKotlinMain`
- ✅ App builds successfully (`./gradlew assembleDebug`)
- ✅ CHANGELOG.md updated

## Screenshots

The changes affect visual appearance in light/dark themes and permission handling:

**Material You Dividers**:
- Dividers now use theme-aware colors instead of hardcoded gray
- Automatically adapts to dynamic color theming

**Permission Flow**:
- RSS feed content notifications now properly request permission on Android 13+
- Shows permission dialog and fallback instructions when denied

## Checklist

- [x] Code follows project style guidelines
- [x] Changes are Material 3 compliant
- [x] Permission handling is consistent across notification toggles
- [x] CHANGELOG.md updated
- [x] Code formatted
- [x] App builds successfully
- [x] No breaking changes

## Related Issues

Fixes issues discovered during code review of Settings Screen.