### PR TITLE
fix: Content carousel now shows blog posts alongside announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Content Carousel Blog Posts**: Fixed carousel not showing blog posts when only announcements were recent
+  - Added `ContentFeedRepository.getLatestUnreadContent()` to fetch only unread content from both sources
+  - Carousel now displays the 3 most recent unread items regardless of content type (announcements or blog posts)
+  - Previously, carousel would show only announcements if they were more recent, even when unread blog posts existed
+  - More efficient: filtering happens at DAO level (SQL) instead of in-memory
+
 ### Removed
 
 - Deleted unused `AnnouncementCarousel.kt` from `ui/home` package - orphaned code from before v2.0.0 when `ContentCarousel` was introduced to support combined announcements and blog posts

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devices/DevicesListStates.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devices/DevicesListStates.kt
@@ -155,13 +155,11 @@ internal fun DevicesList(
     ) {
         // Content carousel at the top
         // Only show if RSS feed content is enabled AND there is unread content
-        // Business Logic: Filter content to only include unread items (isRead = false)
-        // and only display the carousel when there's at least one unread item
-        val unreadContent = latestContent.filter { !it.isRead }
-        if (isRssFeedContentEnabled && unreadContent.isNotEmpty()) {
+        // latestContent already contains only unread items from getLatestUnreadContent()
+        if (isRssFeedContentEnabled && latestContent.isNotEmpty()) {
             item {
                 ContentCarousel(
-                    content = unreadContent,
+                    content = latestContent,
                     isLoading = isContentLoading,
                     onContentClick = onContentItemClick,
                     onViewAllClick = onViewAllContentClick,

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreen.kt
@@ -164,9 +164,10 @@ class TrmnlDevicesPresenter
                 }
             }
 
-            // Collect latest content (announcements + blog posts) from combined feed
+            // Collect latest unread content (announcements + blog posts) from combined feed
+            // Using getLatestUnreadContent() ensures we only get unread items, which is what the carousel displays
             LaunchedEffect(Unit) {
-                contentFeedRepository.getLatestContent(limit = 3).collect { content ->
+                contentFeedRepository.getLatestUnreadContent(limit = 3).collect { content ->
                     latestContent = content
                     isContentLoading = false
                 }


### PR DESCRIPTION
## Problem

The Content Carousel on the Devices screen was only showing announcements and never blog posts, even when unread blog posts existed in the database.

### Root Cause

The carousel uses `ContentFeedRepository.getLatestContent(limit = 3)`, which returns the 3 most recent items **overall** sorted by `publishedDate DESC` across both content types.

**Scenario**: When announcements (Oct 30, 2025) were more recent than blog posts (Oct 28 and earlier), all 3 carousel slots were filled with announcements, leaving no space for blog posts.

**Test Data**:
- 10 blog posts successfully inserted (all unread)
- 3 announcements dated Oct 30, 2025
- Carousel showed: `total=3, announcements=3, blogPosts=0` ❌

## Solution

Created a new `ContentFeedRepository.getLatestUnreadContent(limit: Int)` function that:

1. **Filters at DAO level** (SQL) using `announcementDao.getUnread()` and `blogPostDao.getUnread()`
2. **Returns only unread items** (what the carousel actually displays)
3. **Sorts by published date** (newest first)
4. **Takes top N items** (natural distribution, no forced mixing)

### Benefits

- ✅ **More efficient**: SQL filtering instead of in-memory filtering
- ✅ **Cleaner code**: Removed redundant `filter { !it.isRead }` from UI layer
- ✅ **Better UX**: Carousel now shows blog posts when announcements are read
- ✅ **Natural behavior**: Shows 3 most recent unread items regardless of type

## Changes

### ContentFeedRepository.kt
- Added `getLatestUnreadContent()` function
- Uses `getUnread()` DAO queries for efficient filtering

### TrmnlDevicesScreen.kt
- Changed from `getLatestContent()` to `getLatestUnreadContent()`
- Updated comment to explain why using unread-only function

### DevicesListStates.kt
- Removed manual `filter { !it.isRead }` operation (now redundant)
- `latestContent` already contains only unread items

### CHANGELOG.md
- Documented fix under `[Unreleased] > Fixed`

## Testing

**Before Fix**:
```
Latest content: total=3, announcements=3, blogPosts=0
  - All announcements dated Oct 30, 2025
  - Blog posts excluded (older than announcements)
```

**After Fix**:
```
Latest unread content: total=3, announcements=0, blogPosts=3
  - BLOG POST: Memory Care: Using TRMNL as a Message Board (Oct 30)
  - BLOG POST: Slashing Postage Rates (Again) (Oct 28)
  - BLOG POST: Model X Progress Report (Oct 20)
```

✅ Carousel correctly displays 3 blog posts when all announcements are read

## Checklist

- [x] Code formatted with `./gradlew formatKotlin`
- [x] All tests passing (`./gradlew test`)
- [x] CHANGELOG.md updated
- [x] Manual testing completed
- [x] No PII in code or tests
- [x] Material You compliant (theme-aware colors)
- [x] Follows Circuit architecture patterns

## Related Issues

Fixes bug where users with only unread blog posts saw empty carousel.