### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2025-11-01
+
 ### Fixed
 
 - **Content Carousel Blog Posts**: Fixed carousel not showing blog posts when only announcements were recent
@@ -957,7 +959,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.2.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.2.1...HEAD
+[2.2.1]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/1.7.0...2.0.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 17
-        versionName = "2.2.0"
+        versionCode = 18
+        versionName = "2.2.1"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 2.2.1

This patch release fixes a critical bug in the Content Carousel and removes unused code.

### Version Information

- **Version**: 2.2.1
- **Version Code**: 18
- **Release Date**: November 1, 2025

### Changes

#### Fixed

- **Content Carousel Blog Posts**: Fixed carousel not showing blog posts when only announcements were recent
  - Added `ContentFeedRepository.getLatestUnreadContent()` to fetch only unread content from both sources
  - Carousel now displays the 3 most recent unread items regardless of content type (announcements or blog posts)
  - Previously, carousel would show only announcements if they were more recent, even when unread blog posts existed
  - More efficient: filtering happens at DAO level (SQL) instead of in-memory

#### Removed

- Deleted unused `AnnouncementCarousel.kt` from `ui/home` package - orphaned code from before v2.0.0 when `ContentCarousel` was introduced to support combined announcements and blog posts

### Files Changed

- `app/build.gradle.kts` - Version bump to 2.2.1 (versionCode 18)
- `CHANGELOG.md` - Moved [Unreleased] changes to [2.2.1] section with date

### Checklist

- [x] Version numbers updated in `app/build.gradle.kts`
- [x] CHANGELOG.md updated with release date
- [x] Version comparison links updated
- [x] All changes tested and merged
- [x] Ready for release

### After Merge

1. Create and push tag `2.2.1`
2. Create GitHub release with CHANGELOG excerpt
3. Upload APK to Google Play Console (if applicable)