### PR TITLE
fix: Sync preview image updates between detail and list screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Device Preview Image Refresh**: Thumbnail in device list now updates when preview image is refreshed
+  - Fixed issue where refreshing image in `DevicePreviewScreen` didn't update the thumbnail in `TrmnlDevicesScreen`
+  - Implemented Circuit's `PopResult` pattern to communicate image URL changes between screens
+  - Parent screen now receives and handles result from child screen to update thumbnail state
+  - Ensures visual consistency between preview and list views
 - **Content Carousel Size Transitions**: Smoothly animate carousel height changes when switching between different-sized content
   - Added `animateContentSize()` modifier with 300ms animation to the carousel container
   - Prevents jarring visual jumps when transitioning between announcements (shorter) and blog posts (longer)

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreen.kt
@@ -39,6 +39,7 @@ import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
+import com.slack.circuit.runtime.screen.PopResult
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.sharedelements.SharedElementTransitionScope
 import com.slack.circuit.sharedelements.SharedElementTransitionScope.AnimatedScope.Navigation
@@ -66,6 +67,16 @@ data class DevicePreviewScreen(
     val deviceName: String,
     val imageUrl: String,
 ) : Screen {
+    /**
+     * Result returned when the preview screen is popped.
+     * Contains the device ID and new image URL if the preview was refreshed.
+     */
+    @Parcelize
+    data class Result(
+        val deviceId: String,
+        val newImageUrl: String?,
+    ) : PopResult
+
     data class State(
         val deviceId: String,
         val deviceName: String,
@@ -154,7 +165,15 @@ class DevicePreviewPresenter
                 refreshState = refreshState,
             ) { event ->
                 when (event) {
-                    DevicePreviewScreen.Event.BackClicked -> navigator.pop()
+                    DevicePreviewScreen.Event.BackClicked -> {
+                        // Return the device ID and new image URL if it changed during this session
+                        val result =
+                            DevicePreviewScreen.Result(
+                                deviceId = screen.deviceId,
+                                newImageUrl = if (currentImageUrl != screen.imageUrl) currentImageUrl else null,
+                            )
+                        navigator.pop(result)
+                    }
                     DevicePreviewScreen.Event.DownloadImageClicked -> {
                         if (downloadState !is DevicePreviewScreen.DownloadState.Downloading) {
                             downloadState = DevicePreviewScreen.DownloadState.Downloading


### PR DESCRIPTION
## Problem

When a user opens the device preview screen and taps "Refresh Image", the API returns a new image URL and the preview updates correctly. However, when the user navigates back to the device list screen, the thumbnail still shows the old cached image. This creates a confusing UX where the refresh appears to work but the thumbnail doesn't reflect the change.

## Root Cause

There was no communication mechanism between `DevicePreviewScreen` (child) and `TrmnlDevicesScreen` (parent) to notify about image URL changes. The child screen updated its local state, but the parent screen's `devicePreviews` map remained unchanged.

## Solution

Implemented Circuit's **PopResult pattern** for parent-child screen communication:

### Changes

1. **DevicePreviewScreen.kt**:
   - Added `Result` data class implementing `PopResult` with `deviceId` and `newImageUrl` fields
   - Updated `BackClicked` event handler to pop with result when image URL changed
   - Returns `null` for `newImageUrl` if no refresh occurred during session

2. **TrmnlDevicesScreen.kt**:
   - Added `rememberAnsweringNavigator<DevicePreviewScreen.Result>` to receive results
   - Implemented result handler to update `devicePreviews` map with new image URL
   - Changed `DevicePreviewClicked` event to use `previewNavigator` instead of regular `navigator`

### How It Works

```kotlin
// DevicePreviewScreen pops with result
DevicePreviewScreen.Result(
    deviceId = screen.deviceId,
    newImageUrl = if (currentImageUrl != screen.imageUrl) currentImageUrl else null
)

// TrmnlDevicesScreen receives and handles result
val previewNavigator = rememberAnsweringNavigator<DevicePreviewScreen.Result>(navigator) { result ->
    result.newImageUrl?.let { newUrl ->
        devicePreviews = devicePreviews.toMutableMap().apply {
            existingPreview?.let { preview ->
                put(result.deviceId, preview.copy(imageUrl = newUrl))
            }
        }
    }
}
```

## Testing

**Manual Testing Steps:**
1. ✅ Open device list screen
2. ✅ Tap device preview thumbnail
3. ✅ Verify preview image loads
4. ✅ Tap "Refresh Image" button
5. ✅ Verify new image loads in preview
6. ✅ Tap back button
7. ✅ **Expected**: Thumbnail updates to show new image
8. ✅ **Actual**: Thumbnail now correctly updates

**Automated Testing:**
- ✅ All existing unit tests pass (`./gradlew test`)
- ✅ Code formatted with kotlinter (`./gradlew formatKotlin`)

## Benefits

- ✅ **User Experience**: Visual consistency between preview and list views
- ✅ **Architecture**: Uses idiomatic Circuit patterns (not workarounds)
- ✅ **Maintainability**: Clean, testable, explicit state management
- ✅ **Type Safety**: Compile-time guarantees with sealed `PopResult` type

## References

- [Circuit Navigation with Results](https://slackhq.github.io/circuit/navigation/#results)
- [Circuit PopResult Pattern](https://github.com/slackhq/circuit/blob/main/docs/navigation.md#results)

## Checklist

- [x] Code follows project style guidelines (kotlinter)
- [x] All tests pass
- [x] CHANGELOG.md updated with bug fix details
- [x] Commit message follows conventional commits format
- [x] Manual testing completed successfully
- [x] Implementation follows Circuit best practices