### PR TITLE
feat: Add unread count badges and adaptive welcome button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Content Hub Navigation**: Unread count badges now appear on navigation bar items
+  - Announcements and Blog Posts tabs display badge indicators showing number of unread items
+  - Badges automatically update in real-time as content is read or new items arrive
+  - Uses Material 3's `BadgedBox` component for proper theming and accessibility
+  - Helps users quickly identify where new content is available
 - **Settings Screen**: Version text now links to GitHub releases page when tapped
   - Users can tap on the version information to view all releases at https://github.com/hossain-khan/trmnl-android-buddy/releases/
   - Provides quick access to release notes and changelogs
+
+### Changed
+
+- **Welcome Screen**: Button text now adapts based on user state
+  - New users see "Get Started" button (leads to API token setup)
+  - Returning users see "Dashboard" button (leads to devices/authentication)
+  - Provides clearer context about what action the button performs
 
 ### Fixed
 


### PR DESCRIPTION
## Overview

This PR adds two UX improvements to enhance user awareness and context:

1. **Content Hub Navigation Badges**: Display unread count indicators on navigation tabs
2. **Welcome Screen Adaptive Button**: Show context-aware button text based on user state

## Changes Made

### 1. Content Hub Unread Count Badges

**File**: `app/src/main/java/ink/trmnl/android/buddy/ui/contenthub/ContentHubScreen.kt`

#### State Updates
- Added `announcementsUnreadCount: Int` field to track unread announcements
- Added `blogPostsUnreadCount: Int` field to track unread blog posts

#### Presenter Integration
- Injected `AnnouncementRepository` and `BlogPostRepository` into presenter
- Used `produceRetainedState` to collect real-time unread counts from repository Flows
- Ensures counts survive configuration changes and update reactively

#### UI Implementation
- Wrapped navigation icons in Material 3 `BadgedBox` component
- Display `Badge` with count text when unread items exist (count > 0)
- Updated all preview components to demonstrate badge functionality

**Benefits**:
- ✅ Users can quickly identify which tab has new content
- ✅ Reduces navigation effort to find updates
- ✅ Real-time updates via Flow-based architecture
- ✅ Native Material 3 components for proper theming and accessibility

### 2. Welcome Screen Adaptive Button

**File**: `app/src/main/java/ink/trmnl/android/buddy/ui/welcome/WelcomeScreen.kt`

#### Changes
- Button text now adapts based on `state.hasExistingToken`:
  - **New users** (no token): "Get Started" → leads to API token setup
  - **Returning users** (has token): "Dashboard" → leads to devices/authentication

**Benefits**:
- ✅ Clearer context about what action the button performs
- ✅ Better user experience for returning users
- ✅ Minimal code change with significant UX improvement

## Testing

All quality checks passed:

```bash
# Code formatting
./gradlew formatKotlin
# ✅ BUILD SUCCESSFUL (5 tasks)

# Debug build
./gradlew assembleDebug --no-daemon
# ✅ BUILD SUCCESSFUL (97 tasks)

# Unit tests
./gradlew test --no-daemon
# ✅ BUILD SUCCESSFUL (133 tasks: 12 executed, 121 up-to-date)
```

## Screenshots

_Note: The badges will display actual counts from the repositories when there are unread items. Previews show sample data._

### Content Hub with Badges
- Announcements tab: Badge shows unread count
- Blog Posts tab: Badge shows unread count
- Badges only appear when count > 0

### Welcome Screen
- New users: "Get Started" button
- Returning users: "Dashboard" button

## Documentation

- ✅ CHANGELOG.md updated with both features under `[Unreleased]` section
- ✅ Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format

## Checklist

- [x] Code follows project style guidelines (kotlinter)
- [x] All tests pass
- [x] CHANGELOG.md updated
- [x] Uses Material 3 components (no hardcoded colors)
- [x] Follows Circuit UDF architecture patterns
- [x] Repository integration for real data (not hardcoded)
- [x] Preview components updated
- [x] No compilation errors or warnings

## Related Issues

Closes: N/A (UX improvements)

## Additional Notes

These changes improve the overall polish and user experience of the app by:
1. Providing real-time awareness of new content
2. Reducing cognitive load (clearer button context)
3. Following Material You design principles
4. Using reactive architecture patterns for automatic updates

Both features are independent and could be split into separate PRs if preferred, but they're grouped together as they're both small UX polish improvements.