### PR TITLE
test: Add comprehensive edge case tests for preferences repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Comprehensive unit test coverage for preferences repositories** - Added 26 new edge case tests (from 31 to 57 tests total):
+  - `DeviceTokenRepositoryTest`: Added 14 new tests covering empty tokens, special characters in device IDs, very long tokens, unicode characters, numeric IDs, whitespace handling, case sensitivity, flow isolation, and multiple observers
+  - `UserPreferencesRepositoryTest`: Added 12 new tests covering empty tokens, very long tokens, special characters, boundary values for thresholds (0, 100, negative, >100), rapid changes, boolean flag toggles, and field independence
+  - Tests validate edge cases like empty strings, unicode (🚀, 日本語, العربية), special characters, and data isolation
+  - All tests use fake implementations (no Robolectric) for fast, reliable unit testing
+- **AndroidX Test Core dependency** - Added `androidx.test:core:1.6.1` for unit testing support (ApplicationProvider)
 - **WorkManager Observability and Debugging**: Enhanced monitoring and debugging capabilities for background workers
   - Added `WorkManagerObserver` class to track WorkInfo for all workers (BatteryCollectionWorker, LowBatteryNotificationWorker, BlogPostSyncWorker, AnnouncementSyncWorker)
   - Development screen now displays real-time worker status including state (ENQUEUED, RUNNING, SUCCEEDED, FAILED), run attempts, and constraints

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -178,6 +178,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
     testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
 }
 
 ksp {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,10 @@ biometric = "1.4.0-alpha04"
 # https://github.com/cashapp/turbine
 turbine = "1.2.0"
 
+# AndroidX Test - Core testing utilities
+# https://developer.android.com/jetpack/androidx/releases/test
+androidxTestCore = "1.6.1"
+
 # Telephoto - Zoomable images for Compose
 # https://github.com/saket/telephoto
 telephoto = "0.18.0"
@@ -190,6 +194,10 @@ androidx-biometric = { group = "androidx.biometric", name = "biometric", version
 # Turbine - Testing library for Kotlin Flow
 # https://github.com/cashapp/turbine
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
+
+# AndroidX Test - Core testing utilities
+# https://developer.android.com/jetpack/androidx/releases/test
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 
 # Telephoto - Zoomable images for Compose
 # https://github.com/saket/telephoto


### PR DESCRIPTION
## Summary

Added 26 comprehensive unit tests for preferences repositories to improve code coverage and edge case handling.

## Changes

### Test Coverage Improvements
- **DeviceTokenRepositoryTest**: Added 14 new tests (17 → 31 total)
- **UserPreferencesRepositoryTest**: Added 12 new tests (15 → 27 total)
- **Total**: 57 tests for preferences repositories (+84% increase)

### DeviceTokenRepositoryTest - New Tests (14)

**Edge Cases & Data Validation:**
- ✅ Empty token strings
- ✅ Special characters in device IDs (`_`, `.`, `@`)
- ✅ Very long tokens (1000+ characters)
- ✅ Unicode characters (emojis 🚀, Japanese 日本語, Arabic العربية)
- ✅ Numeric device IDs
- ✅ Whitespace in device IDs (leading/trailing/embedded)
- ✅ Case sensitivity validation

**Flow Behavior:**
- ✅ Flow isolation between devices
- ✅ `clearAll` propagation to flows
- ✅ Individual device clear emits null
- ✅ Multiple observers for same device

**Business Logic:**
- ✅ Empty string vs no token distinction

### UserPreferencesRepositoryTest - New Tests (12)

**Data Validation:**
- ✅ Empty token strings
- ✅ Very long tokens (5000+ characters)
- ✅ Special characters (`!@#$%^&*()`)

**Threshold Boundary Testing:**
- ✅ Boundary values (0 and 100)
- ✅ Negative values
- ✅ Values over 100

**State Management:**
- ✅ Boolean flag toggles (all preferences)
- ✅ One-way flags (onboarding completed)
- ✅ Complete reset validation (all 9 fields)
- ✅ Rapid sequential changes
- ✅ Field independence

### Dependencies
- Added `androidx.test:core:1.6.1` for testing support (ApplicationProvider)

## Testing Strategy

All tests use **fake implementations** (in-memory test doubles) for:
- ⚡ Fast execution (no Robolectric overhead)
- 🎯 Reliable, isolated unit tests
- 📦 No Android framework dependencies needed

## Test Results

✅ All 57 preference tests pass
✅ Code formatted with kotlinter
✅ No breaking changes

## Files Changed

- `app/build.gradle.kts` - Added test dependency
- `gradle/libs.versions.toml` - Added androidx.test.core version
- `app/src/test/java/ink/trmnl/android/buddy/data/preferences/DeviceTokenRepositoryTest.kt`
- `app/src/test/java/ink/trmnl/android/buddy/data/preferences/UserPreferencesRepositoryTest.kt`
- `CHANGELOG.md` - Documented changes

## Checklist

- [x] Tests added and passing
- [x] Code formatted with `./gradlew formatKotlin`
- [x] CHANGELOG.md updated
- [x] Follows project testing guidelines (fake implementations)
- [x] No Robolectric tests (fast unit tests only)