### PR TITLE
fix: resolve dev container permission errors

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -5,9 +5,9 @@ This directory contains the development container configuration for TRMNL Androi
 ## Features
 
 - **Base Image**: Java 21 (Bookworm)
-- **Android SDK**: Automatically installed with latest version
-- **Android NDK**: Latest version
-- **Command Line Tools**: Latest version
+- **Android SDK**: Manually installed via post-create script
+- **Android Command Line Tools**: Version 11076708
+- **Platform Tools**: Latest version
 - **VS Code Extensions**: Kotlin, Gradle, Java, and GitHub Copilot support
 
 ## Environment Variables
@@ -18,11 +18,12 @@ This directory contains the development container configuration for TRMNL Androi
 ## Post-Create Setup
 
 The `post-create.sh` script automatically:
-1. Accepts Android SDK licenses
-2. Installs Android SDK Platform 35 and Build Tools 35.0.0
-3. Updates SDK components
-4. Sets Gradle wrapper permissions
-5. Pre-downloads Gradle dependencies
+1. Downloads and installs Android SDK Command Line Tools if not present
+2. Accepts Android SDK licenses
+3. Installs Android SDK Platform 35 and Build Tools 35.0.0
+4. Updates SDK components
+5. Sets Gradle wrapper permissions
+6. Pre-downloads Gradle dependencies
 
 ## Usage
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,11 +3,6 @@
   "image": "mcr.microsoft.com/devcontainers/java:1-21-bookworm",
   
   "features": {
-    "ghcr.io/devcontainers/features/android-sdk:1": {
-      "version": "latest",
-      "ndkVersion": "latest",
-      "cmdLineToolsVersion": "latest"
-    },
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -4,7 +4,30 @@ set -e
 
 echo "🚀 Setting up Android development environment..."
 
+# Define Android SDK paths
+export ANDROID_HOME="/usr/local/lib/android/sdk"
+export ANDROID_SDK_ROOT="${ANDROID_HOME}"
+export PATH="${PATH}:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools"
+
+# Install Android SDK Command Line Tools if not present
+if [ ! -d "${ANDROID_HOME}/cmdline-tools" ]; then
+    echo "📥 Downloading Android SDK Command Line Tools..."
+    CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip"
+    sudo mkdir -p "${ANDROID_HOME}/cmdline-tools"
+    cd /tmp
+    wget -q "${CMDLINE_TOOLS_URL}" -O commandlinetools.zip
+    unzip -q commandlinetools.zip
+    sudo mv cmdline-tools "${ANDROID_HOME}/cmdline-tools/latest"
+    rm commandlinetools.zip
+    cd -
+    
+    # Set proper ownership and permissions
+    sudo chown -R vscode:vscode "${ANDROID_HOME}"
+    sudo chmod -R 755 "${ANDROID_HOME}"
+fi
+
 # Accept Android SDK licenses
+echo "📝 Accepting Android SDK licenses..."
 yes | sdkmanager --licenses || true
 
 # Install required Android SDK components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fixed dev container permission errors** - Added `sudo` commands in post-create script for Android SDK installation to resolve permission denied errors when creating directories in `/usr/local/lib/android`
 - **Removed untestable ignored unit tests** - Removed 6 DevelopmentPresenterTest tests that were fundamentally untestable due to Circuit test framework limitations with CompositionLocalProvider and Activity context requirements. The removed tests were redundant with existing passing tests.
 
 ### Changed


### PR DESCRIPTION
## Summary

This PR fixes permission errors in the dev container configuration that prevented the Android SDK from being installed properly.

## Changes Made

- **Removed problematic android-sdk feature** from `devcontainer.json` that was causing access permission errors
- **Added manual Android SDK installation** in `post-create.sh` with proper `sudo` commands
- **Set proper ownership** (`vscode:vscode`) and permissions after SDK installation
- **Updated documentation** in `.devcontainer/README.md` to reflect manual installation approach
- **Updated CHANGELOG.md** documenting the fix

## Problem

The dev container was failing with this error:
```
ERR: Feature 'ghcr.io/devcontainers/features/android-sdk:1' could not be processed.
You may not have permission to access this Feature, or may not be logged in.
```

After falling back to a recovery container, the post-create script failed with:
```
mkdir: cannot create directory '/usr/local/lib/android': Permission denied
```

## Solution

1. Removed the inaccessible `android-sdk` feature from devcontainer.json
2. Implemented manual Android SDK installation using `sudo` commands in post-create.sh
3. Set proper ownership to the `vscode` user after installation

## Testing

✅ Dev container builds successfully
✅ Android SDK installed at `/usr/local/lib/android/sdk`
✅ Gradle wrapper executes properly
✅ All dependencies downloaded successfully

## Checklist

- [x] Code formatted with `./gradlew formatKotlin`
- [x] CHANGELOG.md updated
- [x] Dev container tested and working
- [x] Documentation updated