### PR TITLE
Release 2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2025-12-05
+
 ### Fixed
 
 - **Recipe Catalog Crash Fix**: Fixed app crash when browsing Recipe Catalog list with duplicate recipe IDs
@@ -1238,7 +1240,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.1...HEAD
+[2.7.1]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.0...2.7.1
 [2.7.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.6.0...2.7.0
 [2.6.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.5.0...2.6.0
 [2.5.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.4.0...2.5.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 23
-        versionName = "2.7.0"
+        versionCode = 24
+        versionName = "2.7.1"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 2.7.1 - Patch Release

This patch release fixes a critical crash bug in the Recipe Catalog.

### Bug Fix

**Recipe Catalog Crash Fix**: Fixed app crash when browsing Recipe Catalog list with duplicate recipe IDs
- **Error**: `IllegalArgumentException: Key "182990" was already used` in LazyColumn
- **Root Cause**: TRMNL API pagination could return duplicate recipes across pages
- **Solution**: Filter out duplicate recipes by ID when loading more pages using `distinctBy { it.id }`

### Changes

- Updated `versionCode` from 23 to 24
- Updated `versionName` from "2.7.0" to "2.7.1"
- Updated CHANGELOG.md with [2.7.1] section

### Testing

- [x] Bug fix tested by user
- [x] Version numbers updated correctly
- [x] CHANGELOG.md follows Keep a Changelog format
- [x] Version comparison links updated

### Release Checklist

- [x] Version numbers bumped in `app/build.gradle.kts`
- [x] CHANGELOG.md updated with release date
- [x] Release branch created from main
- [x] All changes committed and pushed
- [ ] PR reviewed and merged
- [ ] Tag created and pushed
- [ ] GitHub release created