### PR TITLE
chore: Prepare release 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] - 2025-12-28
+
 ### Fixed
 
 - **Device list loading error**: Fixed app crash when loading device models with missing `published_at` field
@@ -1248,7 +1250,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.1...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.2...HEAD
+[2.7.2]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.1...2.7.2
 [2.7.1]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.0...2.7.1
 [2.7.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.6.0...2.7.0
 [2.6.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.5.0...2.6.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 24
-        versionName = "2.7.1"
+        versionCode = 25
+        versionName = "2.7.2"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
This pull request prepares for the 2.7.2 release with a version bump and changelog updates, and documents a bug fix for device list loading. The main changes are related to release management and bug tracking.

Release management:

* Updated `versionCode` to 25 and `versionName` to "2.7.2" in `app/build.gradle.kts` to reflect the new release version.
* Added a new 2.7.2 section in `CHANGELOG.md` and updated the comparison links to include the new release. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R11) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1251-R1254)

Bug fixes:

* Documented a fix for a crash when loading device models with a missing `published_at` field in the changelog.