### PR TITLE
Release 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-02-10
+
 ### Added
 
 - **Refresh rate display in Device Detail screen**: Added device refresh rate to Current Status Card alongside battery and WiFi metrics
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dynamic mapping system that adapts to TRMNL's refresh rate options
   - Finds closest predefined option using distance calculation for accurate representation
   - Equal-weighted progress bar automatically adjusts to number of available options
-  - Currently supports 11 predefined options: 5, 10, 15, 30, 60, 120, 240, 360, 480, 720, 1440 minutes
+  - Currently supports 13 predefined options: 5, 10, 15, 30, 45, 60, 90, 120, 240, 360, 480, 720, 1440 minutes
   - **Future-proof design**: Simply add new options to `TRMNL_REFRESH_RATE_OPTIONS` list to support them
   - Smart label formatting matching TRMNL's UI: "Every 5 mins", "Hourly", "4x /day", "1x /day", etc.
   - Material 3 design with refresh icon and themed progress indicator
@@ -1353,7 +1355,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.8.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.10.0...HEAD
+[2.10.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.9.0...2.10.0
+[2.9.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.8.0...2.9.0
 [2.8.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.2...2.8.0
 [2.7.2]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.1...2.7.2
 [2.7.1]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.0...2.7.1

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 27
-        versionName = "2.9.0"
+        versionCode = 28
+        versionName = "2.10.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 2.10.0

This release adds refresh rate display to the Device Detail screen and fixes refresh rate formatting inconsistencies.

### Changes in this Release

#### Added ✨
- **Refresh rate display in Device Detail screen**: Shows device refresh rate in Current Status Card alongside battery and WiFi metrics
  - Uses progress bar UI matching existing battery/WiFi design
  - Dynamic mapping system with 13 TRMNL refresh rate options (5, 10, 15, 30, 45, 60, 90, 120, 240, 360, 480, 720, 1440 minutes)
  - Smart label formatting: "Every 5 mins", "Hourly", "Every 2 hrs", etc.
  - Future-proof: easily add new options to `TRMNL_REFRESH_RATE_OPTIONS` list

#### Fixed 🐛
- **Refresh rate display inconsistency**: Device list and details now show consistent refresh rates
  - Both use closest-match algorithm instead of integer division
  - Example: 6812s (113.5 mins) now consistently shows "2h" (mapped to 120 mins)
- **Refresh rate toast inconsistency**: Toast messages now match chip display
  - Example: 6812s shows "2h" chip and "every 2 hours" toast

### Version Updates
- **versionCode**: 27 → 28
- **versionName**: 2.9.0 → 2.10.0

### Checklist
- [x] Version numbers updated in `app/build.gradle.kts`
- [x] CHANGELOG.md updated with version 2.10.0 and date 2026-02-10
- [x] Version comparison links updated
- [x] All changes from `[Unreleased]` moved to `[2.10.0]`
- [x] Changes committed: "chore: Prepare release 2.10.0"
- [x] Release branch pushed: `release/2.10.0`

### Next Steps
After PR is merged:
1. Create and push tag: `git tag -a 2.10.0 -m "Release 2.10.0"`
2. Create GitHub Release with CHANGELOG content