### PR TITLE
fix: Sort playlist items by row_order to match TRMNL website ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Playlist items now display in correct order matching TRMNL website (sorted by row_order ascending)
+
 ### Added
 
 - **Comprehensive unit tests for PlaylistItemsPresenter**: Added 14 test cases covering all presenter functionality

--- a/app/src/main/java/ink/trmnl/android/buddy/data/PlaylistItemsRepository.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/data/PlaylistItemsRepository.kt
@@ -189,7 +189,10 @@ class PlaylistItemsRepositoryImpl
 
             return when (val result = apiService.getPlaylistItems("Bearer $token")) {
                 is ApiResult.Success -> {
-                    val items = result.value.data.map { it.toUi() }
+                    val items =
+                        result.value.data
+                            .map { it.toUi() }
+                            .sortedBy { it.rowOrder } // Sort by row_order ascending (lower values first)
                     cache = CachedData(items, Clock.System.now())
                     _itemsFlow.value = items
                     Timber.d("[PlaylistItemsRepository] Fetched from API - cached ${items.size} items")


### PR DESCRIPTION
## Problem

Playlist items were displaying in the wrong order on the mobile app compared to the TRMNL website. The API returns items unsorted (likely by creation date or ID), but the website displays them sorted by the `row_order` field in ascending order.

## Solution

Added `.sortedBy { it.rowOrder }` in the repository layer after fetching and mapping API data. This ensures items display in the same order as the TRMNL website.

## Changes

- **PlaylistItemsRepository.kt**: Added sorting by `rowOrder` ascending after API data mapping
- **CHANGELOG.md**: Documented the fix under `[Unreleased] > Fixed`

## Technical Details

**Sorting Logic:**
```kotlin
val items = result.value.data
    .map { it.toUi() }
    .sortedBy { it.rowOrder }  // Sort by row_order ascending (lower values first)
```

**Order Verification (from API data):**
- Element of the Day (`row_order: 1073741824`) → Position 1 ✅
- Google Photos (`row_order: 2013265920`) → Position 2 ✅
- Max Payne Quotes (`row_order: 2080374784`) → Position 3 ✅
- Kung Fu Panda Quotes (`row_order: 2097152000`) → Position 4 ✅
- Mashup (`row_order: 2113929216`) → Position 5 ✅
- Durham Waste Collection (`row_order: 2139095040`) → Position 6 ✅
- Mashup (`row_order: 2145386496`) → Position 7 ✅
- Kung Fu Panda Quotes (`row_order: 2146435072`) → Position 8 ✅
- Mashup (`row_order: 2146959360`) → Position 9 ✅

## Testing

- ✅ Code formatted with kotlinter
- ✅ Compilation successful
- ✅ Sorting logic verified against actual API response data
- ✅ Order now matches TRMNL website display

## Impact

- 🎯 **User Experience**: Playlist items now display in consistent order across web and mobile
- 📱 **Visual Parity**: Mobile app matches website ordering exactly
- 🔢 **Correctness**: Items respect the user's configured `row_order` preference

## Files Changed

- `app/src/main/java/ink/trmnl/android/buddy/data/PlaylistItemsRepository.kt` (+4 lines)
- `CHANGELOG.md` (+3 lines)

## Checklist

- [x] Code follows project style guide (kotlinter formatted)
- [x] Changes compile without errors
- [x] CHANGELOG.md updated
- [x] Sorting logic verified with real API data
- [x] No breaking changes