### PR TITLE
Release 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.11.0] - 2026-02-13
+
 ### Added
 - Test coverage for formatRelativeTime() function with 9 comprehensive test cases
 - **Playlist items prefetching on device screen load**: Now automatically prefetches playlist items when DeviceDetailScreen is displayed
@@ -27,9 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Navigates to PlaylistItemsScreen to view device's content rotation schedule
   - Added optional `deviceNumericId` parameter to DeviceDetailScreen for API integration
   - Added `ViewPlaylistItems` event to DeviceDetailScreen.Event
-
-### Changed
-
 - **Playlist Items architecture refactoring**: Migrated from direct API access to repository pattern with domain models
   - Replaced API model usage with `PlaylistItemUi` domain model in UI layer
   - Simplified presenter logic by 55% - removed manual API token handling and 5-case error branching
@@ -1410,7 +1409,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.10.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.11.0...HEAD
+[2.11.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.10.0...2.11.0
 [2.10.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.9.0...2.10.0
 [2.9.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.8.0...2.9.0
 [2.8.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.7.2...2.8.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 28
-        versionName = "2.10.0"
+        versionCode = 29
+        versionName = "2.11.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 2.11.0

Preparing release 2.11.0 with playlist functionality enhancements and improvements.

### Changes Included

**Added:**
- Test coverage for formatRelativeTime() function with 9 comprehensive test cases
- **Playlist items prefetching on device screen load**: Automatically prefetches playlist items when DeviceDetailScreen is displayed
  - Reduces wait time before viewing playlist
  - Shows loading spinner while request is in-flight
  - Caches data for instant access when user navigates to playlist screen

**Changed:**
- Playlist items now show relative time for rendered status (e.g., "Displayed 2 hours ago")
- PlaylistItemsCard displays loading indicator during prefetch
- **Playlist Items navigation**: Added "View" button to navigate from Device Detail to Playlist Items
- **Architecture refactoring**: Migrated to repository pattern with domain models

**Fixed:**
- Playlist Items repository singleton now persists cache across navigation
- Migrated from deprecated kotlinx.datetime to kotlin.time APIs
- Device-specific playlist filtering working correctly
- API serialization error when plugin_setting field is omitted

### Release Details

- Version: 2.11.0
- versionCode: 29
- Release Date: 2026-02-13

### Checklist

- [x] Version numbers updated (versionCode, versionName)
- [x] CHANGELOG.md updated with all changes
- [x] Version links in CHANGELOG.md updated

Ready for merge and tag creation after approval.