### PR TITLE
Release 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-02-13
+
 ### Added
 - **Playlist item visibility toggle**: Added inline eye icon button to toggle visibility status of playlist items
   - Click eye icon to hide/show items from playlist
@@ -1417,7 +1419,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.11.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.12.0...HEAD
+[2.12.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.11.0...2.12.0
 [2.11.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.10.0...2.11.0
 [2.10.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.9.0...2.10.0
 [2.9.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.8.0...2.9.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 29
-        versionName = "2.11.0"
+        versionCode = 30
+        versionName = "2.12.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 2.12.0

### Changes in this Release

#### Added
- **Playlist item visibility toggle**: Added inline eye icon button to toggle visibility status of playlist items
  - Click eye icon to hide/show items from playlist
  - Optimistic UI updates with automatic revert on API failure
  - Uses Material 3 filled/outlined visibility icons based on current state
  - PATCH endpoint integration with `/playlists/items/{id}` API
  - Repository-level caching with reactive updates via StateFlow

- **Improved Device Detail Card**:
  - Item count now appears in headline: `"Playlist Items (8)"`
  - Now playing and up next items displayed as separate bullets in supporting content
  - Up next item intelligently skips hidden items and shows only the next visible item

### Version Updates
- versionCode: 29 → 30
- versionName: 2.11.0 → 2.12.0

### Checklist
- [x] CHANGELOG.md updated
- [x] Version numbers updated
- [x] Code compiles successfully
- [x] All tests passing
- [x] Ready for release