### PR TITLE
Release 2.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.15.0] - 2026-04-18
+
 ### Added
 - **Recipes Health Card on Devices List**: Added compact `RecipesHealthCard` to the main devices dashboard
   - Shows at-a-glance recipe health status ("All healthy" or "N unhealthy") after the content carousel
@@ -1554,7 +1556,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.14.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.15.0...HEAD
+[2.15.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.14.0...2.15.0
 [2.14.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.13.0...2.14.0
 [2.13.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.12.0...2.13.0
 [2.12.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.11.0...2.12.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 32
-        versionName = "2.14.0"
+        versionCode = 33
+        versionName = "2.15.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 2.15.0

### Version Information
- **versionCode**: 33 (from 32)
- **versionName**: 2.15.0 (from 2.14.0)
- **Release Date**: 2026-04-18

### Major Features

#### 1. Recipe Health Card on Devices List
- Compact card showing at-a-glance recipe health status
- Shows "All healthy" or "N unhealthy" status
- Only appears when analytics data is loaded and user has published plugins
- Smooth fade-in animation
- Tap to navigate to full Recipes Analytics screen

#### 2. Settings Screen Reorganization
- Moved Recipe Health Card toggle to dedicated section
- New section positioned after "Low Battery Alerts"
- Toggle only appears when user has published recipes
- Preference saved to DataStore (defaults to enabled)

#### 3. Analytics Testing Framework (DEBUG builds only)
Complete testing suite for simulating different analytics states:
- **NoRecipes** - Test empty-state UI
- **AllHealthy** - Test healthy status (>95% health)
- **AllUnhealthy** - Test unhealthy/error state
- **PartiallyHealthy(count)** - Test mixed health states
- **Loading** - Test loading placeholders
- **Error** - Test error handling
- **LargeDataset(count, percent)** - Test performance
- **Clear Cache** - Test cache invalidation

#### 4. Dynamic Health Status Indicator
- Recipe Analytics screen header updated
- "Your Plugins" → "Your Published Recipes"
- Dynamic status pill showing overall health:
  - Green "Healthy" when all recipes healthy
  - Orange "Degraded" when any recipe degraded
  - Red "Erroring" when any recipe in error state

### Bug Fixes
- Fixed Int to Double type mismatch in mock data generation
- Fixed visibility logic for Recipe Health Card section (only shows when data successfully loaded)
- Fixed NoRecipes scenario to show actual empty-state UI with navigation
- Fixed health percentages normalization from TRMNL API
- Added missing unit tests for new analytics events

### Testing
✅ All 114+ unit tests passing
✅ Code formatted with `formatKotlin`
✅ Material 3 / Material You compliant
✅ Edge-to-edge display compatible

### Files Changed
- `app/build.gradle.kts` - Updated version numbers
- `CHANGELOG.md` - Released [2.15.0] section
- Plus all merged changes from #489 (Recipe Health Card UI Reorganization & Analytics Testing Framework)

### Next Steps
1. ✅ Merge this PR to main
2. Create git tag: `git tag -a 2.15.0 -m "Release 2.15.0"`
3. Push tag: `git push origin 2.15.0`
4. Create GitHub Release with changelog
5. Build and upload APK to Play Store

### Related PR
This release includes all changes from PR #489: Recipe Health Card UI Reorganization & Analytics Testing Framework
