### PR TITLE
fix: Handle empty plugin_setting object in PlaylistItemsResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`PlaylistItemsResponse` parsing failure**: Fixed `MissingFieldException` crash when deserializing `GET /playlists/items` responses where the API returns `plugin_setting: {}` (an empty object) instead of a fully-populated object. Made all fields in `PluginSetting` nullable with defaults so that empty objects deserialize without error. Updated `PlaylistItem.displayName()` to fall back to `"Plugin #<id>"` when `plugin_setting.name` is null. Added a regression test covering the empty object case.
 - **Playlist items screen error message**: Fixed cryptic error message (e.g., `r8.f@b87fba8`) shown when tapping "View" on the Playlist Items section of the device detail screen. In release builds, R8 minification was causing `ApiResult.Failure.toString()` to return an obfuscated class name instead of a readable error. Now uses `ErrorMapper.toUserMessage()` for proper user-friendly error messages.
 
 ### Changed

--- a/api/src/main/java/ink/trmnl/android/buddy/api/models/PlaylistItem.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/models/PlaylistItem.kt
@@ -52,7 +52,7 @@ data class PlaylistItem(
      *
      * Returns the plugin setting name if available, otherwise "Mashup #{id}" for mashup items.
      */
-    fun displayName(): String = pluginSetting?.name ?: "Mashup #$mashupId"
+    fun displayName(): String = pluginSetting?.name ?: mashupId?.let { "Mashup #$it" } ?: "Plugin #$pluginSettingId"
 
     /**
      * Check if this item has never been rendered/displayed.

--- a/api/src/main/java/ink/trmnl/android/buddy/api/models/PluginSetting.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/models/PluginSetting.kt
@@ -9,16 +9,19 @@ import kotlinx.serialization.Serializable
  * Represents a configured plugin instance that can be displayed on a TRMNL device.
  * Each plugin setting has a unique identifier, user-defined name, and plugin type.
  *
- * @property id Unique identifier for this plugin setting
+ * NOTE: The API may return an empty object `{}` for `plugin_setting` when the fields are not
+ * populated, so all fields are nullable with defaults to avoid deserialization failures.
+ *
+ * @property id Unique identifier for this plugin setting (null if not populated by API)
  * @property name User-defined name for the plugin setting (e.g., "Morning Weather", "Family Photos")
  * @property pluginId Identifier for the plugin type (e.g., 28 for Weather, 37 for Custom Content)
  */
 @Serializable
 data class PluginSetting(
     @SerialName("id")
-    val id: Int,
+    val id: Int? = null,
     @SerialName("name")
-    val name: String,
+    val name: String? = null,
     @SerialName("plugin_id")
-    val pluginId: Int,
+    val pluginId: Int? = null,
 )

--- a/api/src/test/java/ink/trmnl/android/buddy/api/TrmnlPlaylistItemsApiTest.kt
+++ b/api/src/test/java/ink/trmnl/android/buddy/api/TrmnlPlaylistItemsApiTest.kt
@@ -298,6 +298,61 @@ class TrmnlPlaylistItemsApiTest : BaseApiTest() {
         }
 
     @Test
+    fun `getPlaylistItems handles empty plugin_setting object from API`() =
+        runTest {
+            // Given: API returns plugin_setting as empty object {} (fields not populated)
+            // This is the real-world behaviour seen in live API responses (scratch_5.json)
+            val responseBody =
+                """
+                {
+                  "data": [
+                    {
+                      "id": 484391,
+                      "device_id": 1002,
+                      "plugin_setting_id": 237340,
+                      "mashup_id": null,
+                      "visible": true,
+                      "rendered_at": "2026-04-23T16:38:53.462Z",
+                      "row_order": -1587270521,
+                      "created_at": "2026-02-03T01:33:53.683Z",
+                      "updated_at": "2026-04-23T16:38:53.462Z",
+                      "mirror": false,
+                      "plugin_setting": {}
+                    }
+                  ]
+                }
+                """.trimIndent()
+
+            mockWebServer.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(responseBody)
+                    .addHeader("Content-Type", "application/json"),
+            )
+
+            // When: Call getPlaylistItems
+            val result = apiService.getPlaylistItems("Bearer test_token")
+
+            // Then: Should parse successfully — empty {} must not cause MissingFieldException
+            assertThat(result).isInstanceOf(ApiResult.Success::class)
+            val successResult = result as ApiResult.Success
+
+            assertThat(successResult.value.data).hasSize(1)
+
+            val item = successResult.value.data[0]
+            assertThat(item.id).isEqualTo(484391)
+            assertThat(item.deviceId).isEqualTo(1002)
+            assertThat(item.pluginSettingId).isEqualTo(237340)
+            // plugin_setting is present but empty — all fields null
+            assertThat(item.pluginSetting).isNotNull()
+            assertThat(item.pluginSetting?.id).isNull()
+            assertThat(item.pluginSetting?.name).isNull()
+            assertThat(item.pluginSetting?.pluginId).isNull()
+            // displayName falls back to "Plugin #<pluginSettingId>" when name is null
+            assertThat(item.displayName()).isEqualTo("Plugin #237340")
+        }
+
+    @Test
     fun `getPlaylistItems returns HTTP 401 for unauthorized`() =
         runTest {
             // Given: Mock server returns 401 Unauthorized


### PR DESCRIPTION
The live API returns `plugin_setting: {}` (an empty JSON object) for playlist items that have a plugin_setting_id. The previous PluginSetting model had non-nullable required fields (id, name, pluginId) which caused a MissingFieldException when deserializing the empty object. Changes:
- Made all PluginSetting fields nullable with null defaults so that empty {} objects deserialize without error
- Updated PlaylistItem.displayName() to fall back to "Plugin #<id>" when plugin_setting.name is null (instead of "Mashup #null")
- Added regression test covering the empty plugin_setting: {} case
- Updated CHANGELOG.md