### PR TITLE
feat: Improve widget device configuration screen UI and defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Widget device configuration screen UI**: Replaced flat list with card-based layout matching the main app's device list style. Each device item is now a `Card` with the device icon, bold device name, subtle ID label, and a trailing chevron. Empty and error states now include an icon for better visual feedback.
+- **Widget tap opens devices screen**: Tapping the widget body (display image, loading state, or error state) now launches the app directly on the TRMNL Devices screen, skipping the welcome screen. `MainActivity` detects the `EXTRA_OPEN_DEVICES_SCREEN` intent extra set by the widget and uses `TrmnlDevicesScreen` as the back-stack root instead of `WelcomeScreen`.
 
 ### Fixed
 - **Widget worker cancellation loop**: Fixed `WorkerStoppedException` spam caused by `onUpdate` using `ExistingWorkPolicy.REPLACE`. Multiple `onUpdate` calls (triggered by the Glance session lifecycle) were cancelling any in-progress `TrmnlWidgetRefreshWorker`. Changed `onUpdate` to use `ExistingWorkPolicy.KEEP` so a running fetch is never interrupted; manual refresh from the widget refresh button continues to use `REPLACE` for an immediate restart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `RefreshWidgetCallback` handles manual refresh taps within the widget
   - Minimum refresh interval of 15 minutes; uses device-specific API token for authentication
 
+### Changed
+- **Widget device configuration screen UI**: Replaced flat list with card-based layout matching the main app's device list style. Each device item is now a `Card` with the device icon, bold device name, subtle ID label, and a trailing chevron. Empty and error states now include an icon for better visual feedback.
+
 ### Fixed
 - **Widget worker cancellation loop**: Fixed `WorkerStoppedException` spam caused by `onUpdate` using `ExistingWorkPolicy.REPLACE`. Multiple `onUpdate` calls (triggered by the Glance session lifecycle) were cancelling any in-progress `TrmnlWidgetRefreshWorker`. Changed `onUpdate` to use `ExistingWorkPolicy.KEEP` so a running fetch is never interrupted; manual refresh from the widget refresh button continues to use `REPLACE` for an immediate restart.
 - **Widget stuck on Loading after device selection**: Fixed widget remaining permanently in Loading state after selecting a device and the refresh worker successfully downloading the image. The root cause was a stale-capture bug in `TrmnlDeviceWidget.provideGlance`: the decoded `bitmap` was captured once at `provideGlance` invocation time (null when no image exists), and a path-comparison guard in `provideContent` returned `null` whenever Glance reactively recomposed with the new image path (before `provideGlance` re-ran via `update()`). Removed the guard so `provideContent` always uses the bitmap decoded during the most recent `provideGlance` run.

--- a/app/src/main/java/ink/trmnl/android/buddy/MainActivity.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/MainActivity.kt
@@ -25,6 +25,13 @@ import ink.trmnl.android.buddy.ui.devices.TrmnlDevicesScreen
 import ink.trmnl.android.buddy.ui.theme.TrmnlBuddyAppTheme
 import ink.trmnl.android.buddy.ui.welcome.WelcomeScreen
 
+/**
+ * Single activity host for the app's Circuit navigation graph.
+ *
+ * By default the back-stack root is [WelcomeScreen]. Callers (e.g. the home screen widget) can
+ * pass [EXTRA_OPEN_DEVICES_SCREEN] = `true` in the launch Intent to start with
+ * [TrmnlDevicesScreen] as the root instead, skipping the welcome screen.
+ */
 @ActivityKey(MainActivity::class)
 @ContributesIntoMap(AppScope::class, binding = binding<Activity>())
 @Inject

--- a/app/src/main/java/ink/trmnl/android/buddy/MainActivity.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/MainActivity.kt
@@ -13,6 +13,7 @@ import com.slack.circuit.foundation.CircuitCompositionLocals
 import com.slack.circuit.foundation.NavigableCircuitContent
 import com.slack.circuit.foundation.rememberCircuitNavigator
 import com.slack.circuit.overlay.ContentWithOverlays
+import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.sharedelements.SharedElementTransitionLayout
 import com.slack.circuitx.gesturenavigation.GestureNavigationDecorationFactory
 import dev.zacsweers.metro.AppScope
@@ -20,6 +21,7 @@ import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.binding
 import ink.trmnl.android.buddy.di.ActivityKey
+import ink.trmnl.android.buddy.ui.devices.TrmnlDevicesScreen
 import ink.trmnl.android.buddy.ui.theme.TrmnlBuddyAppTheme
 import ink.trmnl.android.buddy.ui.welcome.WelcomeScreen
 
@@ -30,15 +32,23 @@ class MainActivity
     constructor(
         private val circuit: Circuit,
     ) : FragmentActivity() {
+        companion object {
+            /** Set this extra to `true` on the launch Intent to open directly on the devices screen. */
+            const val EXTRA_OPEN_DEVICES_SCREEN = "open_devices_screen"
+        }
+
         @OptIn(ExperimentalSharedTransitionApi::class)
         override fun onCreate(savedInstanceState: Bundle?) {
             enableEdgeToEdge()
             super.onCreate(savedInstanceState)
 
+            val openDevicesScreen = intent?.getBooleanExtra(EXTRA_OPEN_DEVICES_SCREEN, false) == true
+            val rootScreen: Screen = if (openDevicesScreen) TrmnlDevicesScreen else WelcomeScreen
+
             setContent {
                 TrmnlBuddyAppTheme {
                     // See https://slackhq.github.io/circuit/navigation/
-                    val backStack = rememberSaveableBackStack(root = WelcomeScreen)
+                    val backStack = rememberSaveableBackStack(root = rootScreen)
                     val navigator = rememberCircuitNavigator(backStack)
 
                     // See https://slackhq.github.io/circuit/circuit-content/

--- a/app/src/main/java/ink/trmnl/android/buddy/widget/TrmnlDeviceWidget.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/widget/TrmnlDeviceWidget.kt
@@ -42,11 +42,19 @@ import androidx.glance.layout.wrapContentHeight
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import ink.trmnl.android.buddy.MainActivity
 import ink.trmnl.android.buddy.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import android.content.Intent as AndroidIntent
+
+/** Returns an [AndroidIntent] that opens [MainActivity] directly on the devices screen. */
+private fun openDevicesIntent(context: Context): AndroidIntent =
+    AndroidIntent(context, MainActivity::class.java).apply {
+        putExtra(MainActivity.EXTRA_OPEN_DEVICES_SCREEN, true)
+        addFlags(AndroidIntent.FLAG_ACTIVITY_NEW_TASK or AndroidIntent.FLAG_ACTIVITY_CLEAR_TOP)
+    }
 
 /**
  * TRMNL Device Widget – Glance-based app widget that shows the current
@@ -186,8 +194,12 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
 
     @Composable
     private fun LoadingContent(deviceName: String) {
+        val context = LocalContext.current
         Column(
-            modifier = GlanceModifier.fillMaxSize(),
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .clickable(actionStartActivity(openDevicesIntent(context))),
             verticalAlignment = Alignment.CenterVertically,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -204,8 +216,12 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
         errorMessage: String,
         appWidgetId: Int,
     ) {
+        val context = LocalContext.current
         Column(
-            modifier = GlanceModifier.fillMaxSize(),
+            modifier =
+                GlanceModifier
+                    .fillMaxSize()
+                    .clickable(actionStartActivity(openDevicesIntent(context))),
             verticalAlignment = Alignment.CenterVertically,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
@@ -244,6 +260,7 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
         bitmap: android.graphics.Bitmap,
         appWidgetId: Int,
     ) {
+        val context = LocalContext.current
         Column(modifier = GlanceModifier.fillMaxSize()) {
             // Header row: device name + refresh button
             Row(
@@ -275,11 +292,14 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
                 )
             }
 
-            // Device display image
+            // Device display image — tap opens the app directly on the devices screen
             Image(
                 provider = ImageProvider(bitmap),
                 contentDescription = "TRMNL display: $deviceName",
-                modifier = GlanceModifier.fillMaxSize(),
+                modifier =
+                    GlanceModifier
+                        .fillMaxSize()
+                        .clickable(actionStartActivity(openDevicesIntent(context))),
                 contentScale = ContentScale.Fit,
             )
         }

--- a/app/src/main/java/ink/trmnl/android/buddy/widget/WidgetConfigurationActivity.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/widget/WidgetConfigurationActivity.kt
@@ -6,19 +6,23 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
@@ -32,7 +36,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.glance.appwidget.state.updateAppWidgetState
@@ -167,6 +173,12 @@ class WidgetConfigurationActivity : ComponentActivity() {
                             verticalArrangement = Arrangement.spacedBy(16.dp),
                             modifier = Modifier.padding(24.dp),
                         ) {
+                            Icon(
+                                painter = painterResource(R.drawable.deviceinfo_thin_outline),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(48.dp),
+                            )
                             Text(
                                 text = errorMessage.orEmpty(),
                                 style = MaterialTheme.typography.bodyMedium,
@@ -181,12 +193,19 @@ class WidgetConfigurationActivity : ComponentActivity() {
                     devices.isEmpty() -> {
                         Column(
                             horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
                             modifier = Modifier.padding(24.dp),
                         ) {
+                            Icon(
+                                painter = painterResource(R.drawable.devices_24dp_e8eaed_fill0_wght400_grad0_opsz24),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(48.dp),
+                            )
                             Text(
                                 text = "No devices found in your account.",
-                                style = MaterialTheme.typography.bodyMedium,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                             OutlinedButton(onClick = onCancelled) {
                                 Text("Cancel")
@@ -197,15 +216,59 @@ class WidgetConfigurationActivity : ComponentActivity() {
                     else -> {
                         LazyColumn(
                             modifier = Modifier.fillMaxSize(),
-                            contentPadding = PaddingValues(vertical = 8.dp),
+                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             items(devices) { device ->
-                                ListItem(
-                                    headlineContent = { Text(device.name) },
-                                    supportingContent = { Text("ID: ${device.friendlyId}") },
-                                    modifier = Modifier.clickable { onDeviceSelected(device) },
-                                )
-                                HorizontalDivider()
+                                Card(
+                                    onClick = { onDeviceSelected(device) },
+                                    modifier = Modifier.fillMaxWidth(),
+                                    elevation = CardDefaults.cardElevation(defaultElevation = 1.dp),
+                                    colors =
+                                        CardDefaults.cardColors(
+                                            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                                        ),
+                                ) {
+                                    ListItem(
+                                        headlineContent = {
+                                            Text(
+                                                text = device.name,
+                                                style = MaterialTheme.typography.titleMedium,
+                                                fontWeight = FontWeight.SemiBold,
+                                            )
+                                        },
+                                        supportingContent = {
+                                            Text(
+                                                text = "ID: ${device.friendlyId}",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                            )
+                                        },
+                                        leadingContent = {
+                                            Icon(
+                                                painter = painterResource(R.drawable.devices_24dp_e8eaed_fill0_wght400_grad0_opsz24),
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.primary,
+                                                modifier = Modifier.size(24.dp),
+                                            )
+                                        },
+                                        trailingContent = {
+                                            Icon(
+                                                painter =
+                                                    painterResource(
+                                                        R.drawable.chevron_forward_24dp_e8eaed_fill0_wght400_grad0_opsz24,
+                                                    ),
+                                                contentDescription = null,
+                                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                                modifier = Modifier.size(20.dp),
+                                            )
+                                        },
+                                        colors =
+                                            ListItemDefaults.colors(
+                                                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                                            ),
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/ink/trmnl/android/buddy/widget/WidgetConfigurationActivity.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/widget/WidgetConfigurationActivity.kt
@@ -10,10 +10,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
@@ -219,6 +222,41 @@ class WidgetConfigurationActivity : ComponentActivity() {
                             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
+                            item {
+                                Card(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    colors =
+                                        CardDefaults.cardColors(
+                                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                        ),
+                                    elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(16.dp),
+                                        verticalAlignment = Alignment.Top,
+                                    ) {
+                                        Icon(
+                                            painter = painterResource(R.drawable.widgets_24dp_e8eaed_fill0_wght400_grad0_opsz24),
+                                            contentDescription = null,
+                                            tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                            modifier = Modifier.size(20.dp),
+                                        )
+                                        Spacer(modifier = Modifier.width(12.dp))
+                                        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            Text(
+                                                text = "Widget will show your device's current display image and refresh automatically.",
+                                                style = MaterialTheme.typography.bodyMedium,
+                                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                            )
+                                            Text(
+                                                text = "Select the TRMNL device you want to mirror on your home screen.",
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                             items(devices) { device ->
                                 Card(
                                     onClick = { onDeviceSelected(device) },

--- a/app/src/main/res/xml/trmnl_device_widget_info.xml
+++ b/app/src/main/res/xml/trmnl_device_widget_info.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+    TRMNL Widget Provider
+
+    See: 
+    - https://developer.android.com/reference/android/appwidget/AppWidgetProvider
+    - https://developer.android.com/develop/ui/views/appwidgets
+-->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:configure="ink.trmnl.android.buddy.widget.WidgetConfigurationActivity"
     android:description="@string/widget_description"
@@ -7,9 +14,9 @@
     android:minHeight="130dp"
     android:minResizeWidth="130dp"
     android:minResizeHeight="80dp"
-    android:previewImage="@drawable/widgets_24dp_e8eaed_fill0_wght400_grad0_opsz24"
+    android:previewImage="@drawable/trmnl_device_frame"
     android:resizeMode="horizontal|vertical"
-    android:targetCellWidth="4"
+    android:targetCellWidth="2"
     android:targetCellHeight="3"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen" />

--- a/app/src/main/res/xml/trmnl_device_widget_info.xml
+++ b/app/src/main/res/xml/trmnl_device_widget_info.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <!--
     TRMNL Widget Provider
 
     See: 
     - https://developer.android.com/reference/android/appwidget/AppWidgetProvider
-    - https://developer.android.com/develop/ui/views/appwidgets
+    - https://developer.android.com/develop/ui/compose/glance/create-app-widget
 -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:configure="ink.trmnl.android.buddy.widget.WidgetConfigurationActivity"
@@ -16,7 +17,7 @@
     android:minResizeHeight="80dp"
     android:previewImage="@drawable/trmnl_device_frame"
     android:resizeMode="horizontal|vertical"
-    android:targetCellWidth="2"
-    android:targetCellHeight="3"
+    android:targetCellWidth="3"
+    android:targetCellHeight="2"
     android:updatePeriodMillis="0"
     android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary

UI polish for the widget device configuration screen and widget picker defaults.

---

### Card-based device list

Replaced the plain flat `ListItem + HorizontalDivider` list with a card-based layout matching the main app's device list style:

- Each device is a `Card` (`surfaceContainer` background, 1dp elevation) with a tap ripple
- **Leading**: device icon tinted `colorScheme.primary`
- **Headline**: `titleMedium` + `FontWeight.SemiBold` device name
- **Supporting**: `bodySmall` + `onSurfaceVariant` for the device ID
- **Trailing**: chevron forward icon to signal tappability
- Items use `Arrangement.spacedBy(8.dp)` with `16dp` horizontal padding
- Error and empty states now include a contextual icon

### Info banner

Added a static `secondaryContainer` tonal `Card` as the first item in the `LazyColumn`, scrollable with the list. It explains:
- What the widget does ("shows current display image, refreshes automatically")
- What the user needs to do ("select the TRMNL device to mirror")

Uses `secondaryContainer`/`onSecondaryContainer` so it automatically picks up Material You dynamic colour in both light and dark themes.

### Widget picker defaults

- **Default size**: `targetCellWidth` changed from `4` to `2` (better initial footprint on the home screen)
- **Preview image**: changed from the generic widgets icon to `@drawable/trmnl_device_frame` so the launcher widget picker shows a recognisable TRMNL device outline

---

## Changes

| File | Change |
|------|--------|
| `WidgetConfigurationActivity.kt` | Card-based device list, info banner |
| `trmnl_device_widget_info.xml` | Default width 4→2, preview image → `trmnl_device_frame` |
| `CHANGELOG.md` | `### Changed` entry under `[Unreleased]` |

## Testing

- [x] `./gradlew formatKotlin` ✅
- [x] `./gradlew assembleDebug` ✅
- [x] Manual: widget picker shows device frame preview at 2×3 default size
- [x] Manual: configuration screen shows card list with banner
