### PR TITLE
feat: Upgrade Glance to 1.2.0-rc01 and improve widget loading/error UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Minimum refresh interval of 15 minutes; uses device-specific API token for authentication
 
 ### Changed
+- **Glance library upgrade**: Updated Glance from `1.1.1` to `1.2.0-rc01`; leverages new `Image` alpha parameter (added in 1.2.0) to render loading and warning icons at reduced opacity for a softer look
+- **Widget loading state UI**: Replaced plain loading text with a clock icon, the device name as a primary label, and a secondary "Fetching display…" caption for clearer visual hierarchy
+- **Widget error state UI**: Replaced raw error text with a warning icon, friendly "Couldn't refresh display" message, and a larger retry button (32 dp) for easier tapping
 - **Widget device configuration screen UI**: Replaced flat list with card-based layout matching the main app's device list style. Each device item is now a `Card` with the device icon, bold device name, subtle ID label, and a trailing chevron. Empty and error states now include an icon for better visual feedback.
 - **Widget tap opens devices screen**: Tapping the widget body (display image, loading state, or error state) now launches the app directly on the TRMNL Devices screen, skipping the welcome screen. `MainActivity` detects the `EXTRA_OPEN_DEVICES_SCREEN` intent extra set by the widget and uses `TrmnlDevicesScreen` as the back-stack root instead of `WelcomeScreen`.
 

--- a/app/src/main/java/ink/trmnl/android/buddy/widget/TrmnlDeviceWidget.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/widget/TrmnlDeviceWidget.kt
@@ -147,7 +147,6 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
                 errorMessage != null ->
                     ErrorContent(
                         deviceName = deviceName,
-                        errorMessage = errorMessage,
                         appWidgetId = appWidgetId,
                     )
 
@@ -203,9 +202,23 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
             verticalAlignment = Alignment.CenterVertically,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Image(
+                provider = ImageProvider(R.drawable.clock_loader_40_24dp_999999_fill0_wght400_grad0_opsz24),
+                contentDescription = null,
+                modifier = GlanceModifier.size(36.dp),
+                alpha = 0.6f,
+            )
+            Spacer(modifier = GlanceModifier.height(10.dp))
+            if (deviceName.isNotEmpty()) {
+                Text(
+                    text = deviceName,
+                    style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 13.sp),
+                )
+                Spacer(modifier = GlanceModifier.height(2.dp))
+            }
             Text(
-                text = if (deviceName.isNotEmpty()) "Loading $deviceName…" else "Loading…",
-                style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 14.sp),
+                text = "Fetching display…",
+                style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 11.sp),
             )
         }
     }
@@ -213,7 +226,6 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
     @Composable
     private fun ErrorContent(
         deviceName: String,
-        errorMessage: String,
         appWidgetId: Int,
     ) {
         val context = LocalContext.current
@@ -225,24 +237,31 @@ class TrmnlDeviceWidget : GlanceAppWidget() {
             verticalAlignment = Alignment.CenterVertically,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Image(
+                provider = ImageProvider(R.drawable.warning_24dp_e8eaed_fill0_wght400_grad0_opsz24),
+                contentDescription = null,
+                modifier = GlanceModifier.size(32.dp),
+                alpha = 0.8f,
+            )
+            Spacer(modifier = GlanceModifier.height(8.dp))
             if (deviceName.isNotEmpty()) {
                 Text(
                     text = deviceName,
-                    style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 12.sp),
+                    style = TextStyle(color = GlanceTheme.colors.onSurface, fontSize = 13.sp),
                 )
-                Spacer(modifier = GlanceModifier.height(4.dp))
+                Spacer(modifier = GlanceModifier.height(2.dp))
             }
             Text(
-                text = errorMessage,
-                style = TextStyle(color = GlanceTheme.colors.error, fontSize = 12.sp),
+                text = "Couldn't refresh display",
+                style = TextStyle(color = GlanceTheme.colors.onSurfaceVariant, fontSize = 11.sp),
             )
-            Spacer(modifier = GlanceModifier.height(8.dp))
+            Spacer(modifier = GlanceModifier.height(12.dp))
             Image(
                 provider = ImageProvider(R.drawable.refresh_24dp_e3e3e3_fill0_wght400_grad0_opsz24),
                 contentDescription = "Retry",
                 modifier =
                     GlanceModifier
-                        .size(24.dp)
+                        .size(32.dp)
                         .clickable(
                             actionRunCallback<RefreshWidgetCallback>(
                                 actionParametersOf(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -81,7 +81,7 @@ robolectric = "4.15"
 
 # AndroidX Biometric - Biometric authentication
 # https://developer.android.com/jetpack/androidx/releases/biometric
-biometric = "1.4.0-alpha04"
+biometric = "1.4.0-alpha07"
 
 # Turbine - Testing library for Kotlin Flow
 # https://github.com/cashapp/turbine
@@ -93,7 +93,7 @@ androidxTestCore = "1.6.1"
 
 # Telephoto - Zoomable images for Compose
 # https://github.com/saket/telephoto
-telephoto = "0.18.0"
+telephoto = "0.19.0"
 
 # Glance - Compose for app widgets
 # https://developer.android.com/jetpack/androidx/releases/glance

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,7 +97,7 @@ telephoto = "0.19.0"
 
 # Glance - Compose for app widgets
 # https://developer.android.com/jetpack/androidx/releases/glance
-glance = "1.1.1"
+glance = "1.2.0-rc01"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }


### PR DESCRIPTION
## Summary

This PR upgrades the Glance library to `1.2.0-rc01` and significantly improves the visual design of the widget's loading and error states, replacing plain text with icon-driven layouts that provide clearer hierarchy and a more polished look.

---

## Changes

### 📦 Glance Library Upgrade: `1.1.1` → `1.2.0-rc01`

Updated both `glance-appwidget` and `glance-material3` to `1.2.0-rc01` in `gradle/libs.versions.toml`.

The key motivator for this upgrade is the new **`alpha` parameter on the `Image` composable** (introduced in `1.2.0-alpha01`), which allows specifying icon opacity (0f–1f) directly without wrapping in an extra composable. This is used in both the loading and error states to render icons at reduced opacity for a softer, less jarring appearance.

Also includes biometric and Telephoto library updates (prior commit on this branch).

---

### ⏳ Widget Loading State — Before vs After

**Before:** Plain text `"Loading <device name>…"` centered in the card — no visual hierarchy, no icon.

**After:** Structured layout with visual hierarchy:
- Clock loader icon at **36 dp**, rendered at **60% opacity** (`alpha = 0.6f`) for a subtle feel
- Device name as a primary label (`13 sp`, `onSurface` color) — shown only when name is available
- `"Fetching display…"` as a secondary caption (`11 sp`, `onSurfaceVariant`) below

```kotlin
Image(
    provider = ImageProvider(R.drawable.clock_loader_40_24dp_999999_fill0_wght400_grad0_opsz24),
    contentDescription = null,
    modifier = GlanceModifier.size(36.dp),
    alpha = 0.6f,  // New Glance 1.2.0 API
)
```

---

### ⚠️ Widget Error State — Before vs After

**Before:** Raw API error message string shown verbatim — confusing and not user-friendly.

**After:** Structured error layout:
- Warning icon at **32 dp**, rendered at **80% opacity** (`alpha = 0.8f`)
- Device name label (when available) for context
- Friendly fixed message: `"Couldn't refresh display"` instead of raw API error strings
- Retry button using a **32 dp** refresh icon (previously smaller), easier to tap
- `errorMessage` parameter **removed** from `ErrorContent` — internal errors no longer surface to the user

```kotlin
Image(
    provider = ImageProvider(R.drawable.warning_24dp_e8eaed_fill0_wght400_grad0_opsz24),
    contentDescription = null,
    modifier = GlanceModifier.size(32.dp),
    alpha = 0.8f,  // New Glance 1.2.0 API
)
```

---

## Files Changed

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Bump `glance` version `1.1.1` → `1.2.0-rc01` |
| `app/.../widget/TrmnlDeviceWidget.kt` | Redesign `LoadingContent` and `ErrorContent`; remove `errorMessage` param |
| `CHANGELOG.md` | Document all changes under `[Unreleased] ### Changed` |

---

## Checklist

- [x] `./gradlew formatKotlin` — passes
- [x] `./gradlew assembleDebug` — BUILD SUCCESSFUL
- [x] `./gradlew test` — all tests passing (0 failures)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] No hardcoded colors — all use `GlanceTheme.colors.*`
- [x] No raw error strings surfaced to users
