### PR TITLE
Release 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.17.0] - 2026-05-03
+
 ### Added
 - **Home screen widget (Compose Glance)**: Added a resizable home screen widget that displays the current e-ink display image from a selected TRMNL device
   - Widget configuration activity (`WidgetConfigurationActivity`) to select a device from the account's device list when adding the widget
@@ -1593,7 +1595,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sensitive information (Device IDs, MAC addresses) obfuscated in UI
 - Debug keystore for development (production releases require separate keystore)
 
-[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.16.0...HEAD
+[unreleased]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.17.0...HEAD
+[2.17.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.16.0...2.17.0
 [2.16.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.15.0...2.16.0
 [2.15.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.14.0...2.15.0
 [2.14.0]: https://github.com/hossain-khan/trmnl-android-buddy/compare/2.13.0...2.14.0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,8 +22,8 @@ android {
 
         // Google Play app versioning - keep in sync with release notes and changelog
         // See https://github.com/hossain-khan/trmnl-android-buddy/blob/main/keystore/README.md#release-keystore-production
-        versionCode = 34
-        versionName = "2.16.0"
+        versionCode = 35
+        versionName = "2.17.0"
 
         // Read key or other properties from local.properties
         val localProperties =


### PR DESCRIPTION
## Release 2.17.0

Bumps `versionCode` 34 → 35 and `versionName` `2.16.0` → `2.17.0`.

---

### Added
- **Home screen widget (Compose Glance)**: Added a resizable home screen widget that displays the current e-ink display image from a selected TRMNL device
  - Widget configuration activity to select a device from the account's device list when adding the widget
  - Automatic image refresh based on the device's `refresh_rate` (minimum 15 minutes)
  - Four widget states: Unconfigured, Loading, Content (with device name and refresh button), and Error (with tap-to-retry)
  - `TrmnlWidgetRefreshWorker` (WorkManager) fetches the current display, downloads and caches the image as PNG, and reschedules itself using the API's `refreshRate`
  - `RefreshWidgetCallback` handles manual refresh taps within the widget

### Changed
- **Glance library upgrade**: Updated Glance from `1.1.1` to `1.2.0-rc01`
- **Widget loading state UI**: Clock icon, device name label, and "Fetching display…" caption
- **Widget error state UI**: Warning icon, friendly "Couldn't refresh display" message, larger retry button (32 dp)
- **Widget device configuration screen UI**: Card-based layout with device icon, bold name, subtle ID label, and trailing chevron
- **Widget tap opens devices screen**: Tapping the widget launches the app directly on the TRMNL Devices screen
- **Widget refresh-in-progress indicator**: Refresh icon replaced with static clock-loader icon immediately on tap
- **Widget configuration disables devices without API key**: Disabled (dimmed) devices shown with "Device API key not configured" subtitle
- **Widget preview image**: Updated widget picker preview to use grey device frame (visible on both light and dark launcher backgrounds)

### Fixed
- **Widget periodic refresh stops after first successful fetch**: Changed `ExistingWorkPolicy.KEEP` → `APPEND_OR_REPLACE` so follow-up refresh jobs are never silently dropped
- **Widget display image not loading on first add**: Configuration activity now performs an inline image fetch in the foreground before returning `RESULT_OK`; also fixed `TrmnlWidgetRefreshWorker` returning `Result.success()` on missing Glance ID (now `Result.retry()`)
- **Widget stays on Loading after inline fetch**: Fixed Glance session deduplication issue by moving bitmap decoding inside `provideContent` using `LaunchedEffect(imageFilePath)`
- **Widget worker cancellation loop**: Changed `onUpdate` to `ExistingWorkPolicy.KEEP` so in-progress fetches are never cancelled by lifecycle `onUpdate` calls
- **Widget stuck on Loading after device selection**: Fixed stale-capture bug in `TrmnlDeviceWidget.provideGlance` where bitmap was captured at invocation time (null) and never updated

## Checklist
- [x] `versionCode` bumped (34 → 35)
- [x] `versionName` bumped (2.16.0 → 2.17.0)
- [x] CHANGELOG.md updated — `[Unreleased]` moved to `[2.17.0] - 2026-05-03`
- [x] Version comparison links updated at bottom of CHANGELOG
