### PR TITLE
docs: Add home screen widget to README features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Your companion app to monitor and manage your TRMNL e-ink displays on the go.
 - 🔋 **Battery Health Tracking** - Automatic weekly battery data collection with historical charts and trajectory visualization
 - 📱 **Device Details** - Comprehensive information including voltage readings, signal strength, and device identifiers
 - 🖼️ **Device Preview** - View current screen content for devices with configured device tokens
+- 🪟 **Home Screen Widget** - Resizable Glance widget that displays your TRMNL e-ink screen directly on your launcher, with auto-refresh and manual refresh support
 - 📰 **Content Feed** - Stay updated with announcements and blog posts from TRMNL
 - 🎨 **Material You Design** - Dynamic theming support (Android 12+) with automatic dark mode
 - 🔐 **Privacy-First** - Obfuscated sensitive information, lock dashboard with biometric authentication 


### PR DESCRIPTION
Adds the home screen widget feature (shipped in 2.17.0) to the README features list.

### Change
- Added `🪟 **Home Screen Widget**` bullet to the Features section describing the resizable Glance widget with auto-refresh and manual refresh support
