### PR TITLE
chore: Clean up build warnings and deprecated API usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Cleaned up build warnings and deprecated API usage
+  - Migrated `content` module from deprecated `kotlinOptions` to `compilerOptions` DSL
+  - Added Room schema export directory for the `app` module
+  - Enabled `-Xannotation-default-target=param-property` to align qualifier annotation targets with Kotlin's future behavior
+  - Replaced deprecated `ClickableText` with `Text` using `LinkAnnotation.Url`
+  - Replaced deprecated `SwipeToDismissBoxState.confirmValueChange` with a `LaunchedEffect` that snaps the state back to settled after toggling read status
+
 ### Fixed
 - Fixed tautological assertions in `WorkerSchedulerTest` that compared each worker ID to itself instead of verifying IDs are distinct across workers
 - Strengthened conditional assertion in `WorkerSchedulerTest` for `triggerLowBatteryNotificationNow` network constraint to always verify the constraint rather than silently skip when work list happens to be empty

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,10 @@ kotlin {
     // See https://kotlinlang.org/docs/gradle-compiler-options.html
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        // Align annotation default targets with Kotlin's future behavior so that
+        // qualifier annotations on constructor parameters (e.g. @ApplicationContext)
+        // are applied to both the parameter and the property backing field.
+        freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
 }
 
@@ -194,11 +198,14 @@ dependencies {
 ksp {
     // Circuit-KSP for Metro
     arg("circuit.codegen.mode", "metro")
-    
+
     // Metro 0.4.0 feature: Enable scoped inject class hints for better performance
     // This allows child graphs to depend on parent-scoped dependencies that are unused
     // See https://zacsweers.github.io/metro/dependency-graphs/
     arg("metro.enableScopedInjectClassHints", "true")
+
+    // Room schema export location
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 

--- a/app/schemas/ink.trmnl.android.buddy.data.database.TrmnlDatabase/2.json
+++ b/app/schemas/ink.trmnl.android.buddy.data.database.TrmnlDatabase/2.json
@@ -1,0 +1,101 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "d41d634e6dc7b18a6c94e936b42fff1c",
+    "entities": [
+      {
+        "tableName": "battery_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `device_id` TEXT NOT NULL, `percent_charged` REAL NOT NULL, `battery_voltage` REAL, `timestamp` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceId",
+            "columnName": "device_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentCharged",
+            "columnName": "percent_charged",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batteryVoltage",
+            "columnName": "battery_voltage",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "bookmarked_recipes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`recipe_id` INTEGER NOT NULL, `recipe_name` TEXT NOT NULL, `recipe_icon_url` TEXT, `installs` INTEGER NOT NULL, `forks` INTEGER NOT NULL, `bookmarked_at` INTEGER NOT NULL, PRIMARY KEY(`recipe_id`))",
+        "fields": [
+          {
+            "fieldPath": "recipeId",
+            "columnName": "recipe_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeName",
+            "columnName": "recipe_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recipeIconUrl",
+            "columnName": "recipe_icon_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "installs",
+            "columnName": "installs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forks",
+            "columnName": "forks",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarked_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "recipe_id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd41d634e6dc7b18a6c94e936b42fff1c')"
+    ]
+  }
+}

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/announcements/AnnouncementsContent.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/announcements/AnnouncementsContent.kt
@@ -475,17 +475,14 @@ private fun AnnouncementItem(
     onToggleReadStatus: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val dismissState =
-        rememberSwipeToDismissBoxState(
-            confirmValueChange = { dismissValue ->
-                if (dismissValue == SwipeToDismissBoxValue.EndToStart || dismissValue == SwipeToDismissBoxValue.StartToEnd) {
-                    onToggleReadStatus()
-                    false // Don't actually dismiss, just toggle
-                } else {
-                    false
-                }
-            },
-        )
+    val dismissState = rememberSwipeToDismissBoxState()
+
+    LaunchedEffect(dismissState.currentValue) {
+        if (dismissState.currentValue != SwipeToDismissBoxValue.Settled) {
+            onToggleReadStatus()
+            dismissState.snapTo(SwipeToDismissBoxValue.Settled)
+        }
+    }
 
     // Track press state for animation
     val interactionSource = remember { MutableInteractionSource() }

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/recipescatalog/RecipeDetailBottomSheet.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/recipescatalog/RecipeDetailBottomSheet.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -31,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -226,7 +224,6 @@ fun RecipeDetailBottomSheet(
                 Spacer(modifier = Modifier.height(8.dp))
 
                 // Render HTML description with clickable links
-                val uriHandler = LocalUriHandler.current
                 val linkColor = MaterialTheme.colorScheme.primary
                 val annotatedDescription =
                     remember(description, linkColor) {
@@ -236,23 +233,12 @@ fun RecipeDetailBottomSheet(
                         )
                     }
 
-                ClickableText(
+                Text(
                     text = annotatedDescription,
                     style =
                         MaterialTheme.typography.bodyMedium.copy(
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         ),
-                    onClick = { offset ->
-                        annotatedDescription
-                            .getStringAnnotations(
-                                tag = "URL",
-                                start = offset,
-                                end = offset,
-                            ).firstOrNull()
-                            ?.let { annotation ->
-                                uriHandler.openUri(annotation.item)
-                            }
-                    },
                 )
             }
 

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/utils/HtmlTextUtils.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/utils/HtmlTextUtils.kt
@@ -4,7 +4,9 @@ import android.text.Spanned
 import android.text.style.URLSpan
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.text.HtmlCompat
@@ -30,18 +32,18 @@ fun htmlToAnnotatedString(
         spanned.getSpans(0, spanned.length, URLSpan::class.java).forEach { urlSpan ->
             val start = spanned.getSpanStart(urlSpan)
             val end = spanned.getSpanEnd(urlSpan)
-            addStyle(
-                style =
-                    SpanStyle(
-                        color = linkColor,
-                        textDecoration = TextDecoration.Underline,
-                    ),
-                start = start,
-                end = end,
-            )
-            addStringAnnotation(
-                tag = "URL",
-                annotation = urlSpan.url,
+            addLink(
+                LinkAnnotation.Url(
+                    url = urlSpan.url,
+                    styles =
+                        TextLinkStyles(
+                            style =
+                                SpanStyle(
+                                    color = linkColor,
+                                    textDecoration = TextDecoration.Underline,
+                                ),
+                        ),
+                ),
                 start = start,
                 end = end,
             )

--- a/content/build.gradle.kts
+++ b/content/build.gradle.kts
@@ -36,8 +36,12 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions {
-        jvmTarget = "11"
+}
+
+kotlin {
+    // See https://kotlinlang.org/docs/gradle-compiler-options.html
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }
 


### PR DESCRIPTION
## Summary
Cleaned up the build/compiler warnings surfaced during `./gradlew assembleDebug` and `./gradlew test`.

## Changes
- Migrated `content` module from deprecated `kotlinOptions` to `compilerOptions` DSL.
- Added Room schema export directory (`app/schemas/`) for the `app` module to resolve the KSP warning.
- Enabled `-Xannotation-default-target=param-property` compiler option so qualifier annotations on constructor parameters (e.g. `@ApplicationContext`) align with Kotlin's future behavior.
- Replaced deprecated `ClickableText` with `Text` using `LinkAnnotation.Url` for clickable HTML links.
- Replaced deprecated `SwipeToDismissBoxState.confirmValueChange` with a `LaunchedEffect` that snaps the dismiss state back to `Settled` after toggling read status.
- Updated `CHANGELOG.md`.

## Verification
- `./gradlew formatKotlin` ✅
- `./gradlew lintKotlin` ✅
- `./gradlew test` ✅
- `./gradlew assembleDebug` ✅

## Notes
The following warnings remain but originate outside project code and are not addressed here:
- Gradle 10 "multi-string notation" deprecation warnings from internal AGP dependencies.
- `sun.misc.Unsafe::objectFieldOffset` JVM warnings emitted by the Kotlin compiler.
- Robolectric `CloseGuard` SQLite leak warnings in `WorkerSchedulerTest`.
