### PR TITLE
feat(preview): add next display image loading and navigation with caching (#517)

### DIFF
--- a/api/src/main/java/ink/trmnl/android/buddy/api/TrmnlApiService.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/TrmnlApiService.kt
@@ -177,6 +177,51 @@ interface TrmnlApiService {
         @Header("Access-Token") deviceApiKey: String,
     ): ApiResult<Display, ApiError>
 
+    /**
+     * Fetch the next display screen for a specific device.
+     *
+     * This endpoint uses Device API authentication (Access-Token header)
+     * and instructs the server to render and return the next display screen in the playlist rotation.
+     *
+     * Note: This is a Device API endpoint that requires the device's API key,
+     * not the user's Account API key.
+     *
+     * @param deviceApiKey Device API Key (format: "abc-123")
+     * @return ApiResult containing display data or error
+     *
+     * Example response:
+     * ```json
+     * {
+     *   "status": 200,
+     *   "refresh_rate": 300,
+     *   "image_url": "https://trmnl.com/images/system_screens/setup_logo/og_plus.png",
+     *   "filename": "setup-logo.bmp"
+     * }
+     * ```
+     *
+     * Example usage:
+     * ```kotlin
+     * when (val result = api.getDisplay("abc-123")) {
+     *     is ApiResult.Success -> {
+     *         val display = result.value
+     *         println("Next display image: ${display.imageUrl}")
+     *     }
+     *     is ApiResult.Failure.HttpFailure -> when (result.code) {
+     *         404 -> println("Device not found")
+     *         401 -> println("Unauthorized")
+     *         else -> println("HTTP error: ${result.code}")
+     *     }
+     *     is ApiResult.Failure.NetworkFailure -> println("Network error")
+     *     is ApiResult.Failure.ApiFailure -> println("API error: ${result.error}")
+     *     is ApiResult.Failure.UnknownFailure -> println("Unknown error")
+     * }
+     * ```
+     */
+    @GET("display")
+    suspend fun getDisplay(
+        @Header("Access-Token") deviceApiKey: String,
+    ): ApiResult<Display, ApiError>
+
     // ========================================
     // Playlists API
     // ========================================

--- a/api/src/test/java/ink/trmnl/android/buddy/api/TrmnlDisplayApiTest.kt
+++ b/api/src/test/java/ink/trmnl/android/buddy/api/TrmnlDisplayApiTest.kt
@@ -209,4 +209,84 @@ class TrmnlDisplayApiTest : BaseApiTest() {
             assertThat(display.renderedAt).isNotNull()
             assertThat(display.renderedAt).isEqualTo("2024-12-25T18:30:00Z")
         }
+
+    @Test
+    fun `getDisplay returns success with next display data`() =
+        runTest {
+            // Given
+            val deviceApiKey = "abc-123"
+            val mockResponse =
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(
+                        """
+                        {
+                          "status": 200,
+                          "refresh_rate": 300,
+                          "image_url": "https://trmnl.com/images/system_screens/setup_logo/og_plus.png",
+                          "filename": "next-logo.bmp"
+                        }
+                        """.trimIndent(),
+                    )
+            mockWebServer.enqueue(mockResponse)
+
+            // When
+            val result = apiService.getDisplay(deviceApiKey)
+
+            // Then
+            assertThat(result).isInstanceOf<ApiResult.Success<*>>()
+            val successResult = result as ApiResult.Success
+            val display = successResult.value
+
+            assertThat(display.status).isEqualTo(200)
+            assertThat(display.refreshRate).isEqualTo(300)
+            assertThat(display.imageUrl).isEqualTo("https://trmnl.com/images/system_screens/setup_logo/og_plus.png")
+            assertThat(display.filename).isEqualTo("next-logo.bmp")
+
+            // Verify request
+            val request = mockWebServer.takeRequest()
+            assertThat(request.path).isEqualTo("/display")
+            assertThat(request.method).isEqualTo("GET")
+            assertThat(request.getHeader("Access-Token")).isEqualTo(deviceApiKey)
+        }
+
+    @Test
+    fun `getDisplay returns 401 Unauthorized`() =
+        runTest {
+            // Given
+            val deviceApiKey = "invalid-key"
+            val mockResponse =
+                MockResponse()
+                    .setResponseCode(401)
+                    .setBody(
+                        """
+                        {
+                          "error": "Unauthorized",
+                          "message": "Invalid or missing device API token"
+                        }
+                        """.trimIndent(),
+                    )
+            mockWebServer.enqueue(mockResponse)
+
+            // When
+            val result = apiService.getDisplay(deviceApiKey)
+
+            // Then
+            assertThat(result).isInstanceOf<ApiResult.Failure.HttpFailure<*>>()
+            val failure = result as ApiResult.Failure.HttpFailure
+            assertThat(failure.code).isEqualTo(401)
+        }
+
+    @Test
+    fun `getDisplay handles network failure`() =
+        runTest {
+            // Given
+            mockWebServer.shutdown()
+
+            // When
+            val result = apiService.getDisplay("abc-123")
+
+            // Then
+            assertThat(result).isInstanceOf<ApiResult.Failure.NetworkFailure>()
+        }
 }

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewContent.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewContent.kt
@@ -2,10 +2,13 @@ package ink.trmnl.android.buddy.ui.devicepreview
 
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -14,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -97,6 +101,25 @@ fun DevicePreviewContent(
             }
             DevicePreviewScreen.RefreshState.Idle,
             DevicePreviewScreen.RefreshState.Refreshing,
+            -> {
+                // No action needed
+            }
+        }
+    }
+
+    // Handle load next state with snackbar messages
+    LaunchedEffect(state.loadNextState) {
+        when (val loadNextState = state.loadNextState) {
+            is DevicePreviewScreen.LoadNextState.Success -> {
+                snackbarHostState.showSnackbar(loadNextState.message)
+                state.eventSink(DevicePreviewScreen.Event.DismissLoadNextSnackbar)
+            }
+            is DevicePreviewScreen.LoadNextState.Error -> {
+                snackbarHostState.showSnackbar(loadNextState.message)
+                state.eventSink(DevicePreviewScreen.Event.DismissLoadNextSnackbar)
+            }
+            DevicePreviewScreen.LoadNextState.Idle,
+            DevicePreviewScreen.LoadNextState.Loading,
             -> {
                 // No action needed
             }
@@ -216,6 +239,75 @@ fun DevicePreviewContent(
                         }
                     },
                 )
+            }
+
+            // Bottom floating navigation pill (only shown when device is configured with API key)
+            if (state.isConfigured) {
+                Surface(
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 24.dp),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f),
+                    tonalElevation = 6.dp,
+                    shadowElevation = 6.dp,
+                ) {
+                    Row(
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        IconButton(
+                            onClick = { state.eventSink(DevicePreviewScreen.Event.PreviousImageClicked) },
+                            enabled = state.canGoPrevious && !state.isLoadingNext,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.chevron_backward_24dp_e8eaed_fill0_wght400_grad0_opsz24),
+                                contentDescription = "Previous display image",
+                                modifier = Modifier.size(24.dp),
+                                tint =
+                                    if (state.canGoPrevious && !state.isLoadingNext) {
+                                        MaterialTheme.colorScheme.primary
+                                    } else {
+                                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                    },
+                            )
+                        }
+
+                        Text(
+                            text = "${state.currentImageIndex + 1} / ${state.totalImages}",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            modifier = Modifier.padding(horizontal = 4.dp),
+                        )
+
+                        IconButton(
+                            onClick = { state.eventSink(DevicePreviewScreen.Event.NextImageClicked) },
+                            enabled = state.canGoNext && !state.isLoadingNext,
+                        ) {
+                            if (state.isLoadingNext) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(18.dp),
+                                    color = MaterialTheme.colorScheme.primary,
+                                    strokeWidth = 2.dp,
+                                )
+                            } else {
+                                Icon(
+                                    painter = painterResource(R.drawable.chevron_forward_24dp_e8eaed_fill0_wght400_grad0_opsz24),
+                                    contentDescription = "Next display image",
+                                    modifier = Modifier.size(24.dp),
+                                    tint =
+                                        if (state.canGoNext && !state.isLoadingNext) {
+                                            MaterialTheme.colorScheme.primary
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                                        },
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewContent.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewContent.kt
@@ -1,5 +1,6 @@
 package ink.trmnl.android.buddy.ui.devicepreview
 
+import android.content.res.Configuration
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -243,11 +245,15 @@ fun DevicePreviewContent(
 
             // Bottom floating navigation pill (only shown when device is configured with API key)
             if (state.isConfigured) {
+                val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
                 Surface(
                     modifier =
                         Modifier
-                            .align(Alignment.BottomCenter)
-                            .padding(bottom = 24.dp),
+                            .align(if (isLandscape) Alignment.BottomEnd else Alignment.BottomCenter)
+                            .padding(
+                                end = if (isLandscape) 24.dp else 0.dp,
+                                bottom = 24.dp,
+                            ),
                     shape = CircleShape,
                     color = MaterialTheme.colorScheme.surfaceContainerHigh.copy(alpha = 0.92f),
                     tonalElevation = 6.dp,

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewPresenter.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewPresenter.kt
@@ -1,7 +1,9 @@
 package ink.trmnl.android.buddy.ui.devicepreview
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
@@ -32,6 +34,12 @@ class DevicePreviewPresenter
     ) : Presenter<DevicePreviewScreen.State> {
         @Composable
         override fun present(): DevicePreviewScreen.State {
+            var isConfigured by rememberRetained { mutableStateOf(false) }
+
+            LaunchedEffect(screen.deviceId) {
+                isConfigured = deviceTokenRepository.hasDeviceToken(screen.deviceId)
+            }
+
             var downloadState by rememberRetained {
                 mutableStateOf<DevicePreviewScreen.DownloadState>(
                     DevicePreviewScreen.DownloadState.Idle,
@@ -44,16 +52,31 @@ class DevicePreviewPresenter
                 )
             }
 
-            var currentImageUrl by rememberRetained { mutableStateOf(screen.imageUrl) }
+            var loadNextState by rememberRetained {
+                mutableStateOf<DevicePreviewScreen.LoadNextState>(
+                    DevicePreviewScreen.LoadNextState.Idle,
+                )
+            }
 
+            var cachedImages by rememberRetained { mutableStateOf(listOf(screen.imageUrl)) }
+            var currentImageIndex by rememberRetained { mutableIntStateOf(0) }
+
+            val currentImageUrl = cachedImages.getOrElse(currentImageIndex) { screen.imageUrl }
             val scope = rememberCoroutineScope()
 
             return DevicePreviewScreen.State(
                 deviceId = screen.deviceId,
                 deviceName = screen.deviceName,
                 imageUrl = currentImageUrl,
+                isConfigured = isConfigured,
+                currentImageIndex = currentImageIndex,
+                totalImages = cachedImages.size,
+                canGoPrevious = currentImageIndex > 0,
+                canGoNext = isConfigured,
+                isLoadingNext = loadNextState is DevicePreviewScreen.LoadNextState.Loading,
                 downloadState = downloadState,
                 refreshState = refreshState,
+                loadNextState = loadNextState,
             ) { event ->
                 when (event) {
                     DevicePreviewScreen.Event.BackClicked -> {
@@ -70,17 +93,68 @@ class DevicePreviewPresenter
                             downloadState = DevicePreviewScreen.DownloadState.Downloading
                         }
                     }
+                    DevicePreviewScreen.Event.PreviousImageClicked -> {
+                        if (currentImageIndex > 0) {
+                            currentImageIndex--
+                        }
+                    }
+                    DevicePreviewScreen.Event.NextImageClicked -> {
+                        if (currentImageIndex < cachedImages.lastIndex) {
+                            currentImageIndex++
+                        } else if (isConfigured && loadNextState !is DevicePreviewScreen.LoadNextState.Loading) {
+                            loadNextState = DevicePreviewScreen.LoadNextState.Loading
+                            scope.launch {
+                                val token = deviceTokenRepository.getDeviceToken(screen.deviceId)
+                                if (token != null) {
+                                    when (val result = apiService.getDisplay(token)) {
+                                        is ApiResult.Success -> {
+                                            val newImageUrl = result.value.imageUrl
+                                            if (newImageUrl != null) {
+                                                if (newImageUrl != currentImageUrl) {
+                                                    cachedImages = cachedImages + newImageUrl
+                                                    currentImageIndex = cachedImages.lastIndex
+                                                }
+                                                loadNextState =
+                                                    DevicePreviewScreen.LoadNextState.Success(
+                                                        newImageUrl = newImageUrl,
+                                                        message = "Next display image loaded",
+                                                    )
+                                            } else {
+                                                loadNextState =
+                                                    DevicePreviewScreen.LoadNextState.Error(
+                                                        message = "No display image returned",
+                                                    )
+                                            }
+                                        }
+                                        is ApiResult.Failure -> {
+                                            loadNextState =
+                                                DevicePreviewScreen.LoadNextState.Error(
+                                                    message = result.toUserMessage(),
+                                                )
+                                        }
+                                    }
+                                } else {
+                                    loadNextState =
+                                        DevicePreviewScreen.LoadNextState.Error(
+                                            message = "Device API key not found. Please configure it in settings.",
+                                        )
+                                }
+                            }
+                        }
+                    }
                     DevicePreviewScreen.Event.RefreshImageClicked -> {
                         if (refreshState !is DevicePreviewScreen.RefreshState.Refreshing) {
                             refreshState = DevicePreviewScreen.RefreshState.Refreshing
                             scope.launch {
-                                val deviceToken = deviceTokenRepository.getDeviceToken(screen.deviceId)
-                                if (deviceToken != null) {
-                                    when (val result = apiService.getDisplayCurrent(deviceToken)) {
+                                val token = deviceTokenRepository.getDeviceToken(screen.deviceId)
+                                if (token != null) {
+                                    when (val result = apiService.getDisplayCurrent(token)) {
                                         is ApiResult.Success -> {
                                             val newImageUrl = result.value.imageUrl
                                             if (newImageUrl != null) {
-                                                currentImageUrl = newImageUrl
+                                                val updatedList = cachedImages.toMutableList()
+                                                updatedList[currentImageIndex] = newImageUrl
+                                                cachedImages = updatedList
                                                 refreshState =
                                                     DevicePreviewScreen.RefreshState.Success(
                                                         newImageUrl = newImageUrl,
@@ -114,6 +188,9 @@ class DevicePreviewPresenter
                     }
                     DevicePreviewScreen.Event.DismissRefreshSnackbar -> {
                         refreshState = DevicePreviewScreen.RefreshState.Idle
+                    }
+                    DevicePreviewScreen.Event.DismissLoadNextSnackbar -> {
+                        loadNextState = DevicePreviewScreen.LoadNextState.Idle
                     }
                 }
             }

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreen.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreen.kt
@@ -30,8 +30,15 @@ data class DevicePreviewScreen(
         val deviceId: String,
         val deviceName: String,
         val imageUrl: String,
+        val isConfigured: Boolean = false,
+        val currentImageIndex: Int = 0,
+        val totalImages: Int = 1,
+        val canGoPrevious: Boolean = false,
+        val canGoNext: Boolean = false,
+        val isLoadingNext: Boolean = false,
         val downloadState: DownloadState = DownloadState.Idle,
         val refreshState: RefreshState = RefreshState.Idle,
+        val loadNextState: LoadNextState = LoadNextState.Idle,
         val eventSink: (Event) -> Unit = {},
     ) : CircuitUiState
 
@@ -64,6 +71,21 @@ data class DevicePreviewScreen(
         ) : RefreshState
     }
 
+    sealed interface LoadNextState {
+        data object Idle : LoadNextState
+
+        data object Loading : LoadNextState
+
+        data class Success(
+            val newImageUrl: String,
+            val message: String,
+        ) : LoadNextState
+
+        data class Error(
+            val message: String,
+        ) : LoadNextState
+    }
+
     sealed interface Event : CircuitUiEvent {
         data object BackClicked : Event
 
@@ -71,8 +93,14 @@ data class DevicePreviewScreen(
 
         data object RefreshImageClicked : Event
 
+        data object PreviousImageClicked : Event
+
+        data object NextImageClicked : Event
+
         data object DismissSnackbar : Event
 
         data object DismissRefreshSnackbar : Event
+
+        data object DismissLoadNextSnackbar : Event
     }
 }

--- a/app/src/test/java/ink/trmnl/android/buddy/data/RecipesRepositoryTest.kt
+++ b/app/src/test/java/ink/trmnl/android/buddy/data/RecipesRepositoryTest.kt
@@ -187,6 +187,8 @@ class RecipesRepositoryTest {
 
         override suspend fun getDisplayCurrent(deviceApiKey: String): ApiResult<Display, ApiError> = throw NotImplementedError()
 
+        override suspend fun getDisplay(deviceApiKey: String): ApiResult<Display, ApiError> = throw NotImplementedError()
+
         override suspend fun userInfo(authorization: String): ApiResult<UserResponse, ApiError> = throw NotImplementedError()
 
         override suspend fun getCategories(): ApiResult<CategoriesResponse, ApiError> = throw NotImplementedError()

--- a/app/src/test/java/ink/trmnl/android/buddy/fakes/FakeTrmnlApiService.kt
+++ b/app/src/test/java/ink/trmnl/android/buddy/fakes/FakeTrmnlApiService.kt
@@ -33,6 +33,7 @@ class FakeTrmnlApiService : TrmnlApiService {
     var getRecipeResult: ApiResult<RecipeDetailResponse, ApiError>? = null
     var getDeviceModelsResult: ApiResult<DeviceModelsResponse, ApiError>? = null
     var getDisplayCurrentResult: ApiResult<Display, ApiError>? = null
+    var getDisplayResult: ApiResult<Display, ApiError>? = null
     var getPlaylistItemsResult: ApiResult<PlaylistItemsResponse, ApiError>? = null
     var getRecipesAnalyticsResult: ApiResult<RecipesAnalyticsResponse, ApiError>? = null
 
@@ -75,6 +76,9 @@ class FakeTrmnlApiService : TrmnlApiService {
 
     override suspend fun getDisplayCurrent(deviceApiKey: String): ApiResult<Display, ApiError> =
         getDisplayCurrentResult ?: throw NotImplementedError("getDisplayCurrentResult not implemented")
+
+    override suspend fun getDisplay(deviceApiKey: String): ApiResult<Display, ApiError> =
+        getDisplayResult ?: throw NotImplementedError("getDisplayResult not implemented")
 
     override suspend fun getPlaylistItems(authorization: String): ApiResult<PlaylistItemsResponse, ApiError> {
         lastAuthorizationHeader = authorization

--- a/app/src/test/java/ink/trmnl/android/buddy/ui/devicecatalog/DeviceCatalogPresenterTest.kt
+++ b/app/src/test/java/ink/trmnl/android/buddy/ui/devicecatalog/DeviceCatalogPresenterTest.kt
@@ -427,6 +427,8 @@ private open class FakeApiService(
 
     override suspend fun getDisplayCurrent(deviceApiKey: String) = throw NotImplementedError("Not needed for DeviceCatalogPresenter tests")
 
+    override suspend fun getDisplay(deviceApiKey: String) = throw NotImplementedError("Not needed for DeviceCatalogPresenter tests")
+
     override suspend fun userInfo(authorization: String) = throw NotImplementedError("Not needed for DeviceCatalogPresenter tests")
 
     override suspend fun getRecipes(

--- a/app/src/test/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreenTest.kt
+++ b/app/src/test/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreenTest.kt
@@ -2,7 +2,10 @@ package ink.trmnl.android.buddy.ui.devicepreview
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import com.slack.eithernet.ApiResult
@@ -10,7 +13,6 @@ import ink.trmnl.android.buddy.api.TrmnlApiService
 import ink.trmnl.android.buddy.api.models.ApiError
 import ink.trmnl.android.buddy.api.models.CategoriesResponse
 import ink.trmnl.android.buddy.api.models.Display
-import ink.trmnl.android.buddy.data.preferences.DeviceTokenRepository
 import ink.trmnl.android.buddy.fakes.FakeDeviceTokenRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -19,12 +21,13 @@ import java.io.IOException
 /**
  * Tests for DevicePreviewScreen presenter.
  *
- * Tests the refresh functionality including:
+ * Tests the refresh and display navigation functionality including:
  * - Successful refresh
- * - HTTP 429 (rate limit) error handling
- * - HTTP 500 (server error) error handling
- * - Network error handling
+ * - HTTP error and network error handling
  * - Missing device token handling
+ * - Next display API calls and caching
+ * - Backward/forward navigation in image history
+ * - Navigation pill visibility based on token configuration
  */
 class DevicePreviewScreenTest {
     private val testScreen =
@@ -35,7 +38,7 @@ class DevicePreviewScreenTest {
         )
 
     @Test
-    fun `presenter returns initial state with idle refresh state`() =
+    fun `presenter returns initial state with idle refresh state and unconfigured when no token`() =
         runTest {
             val navigator = FakeNavigator(testScreen)
             val apiService = FakeApiService()
@@ -47,7 +50,36 @@ class DevicePreviewScreenTest {
                 assertThat(state.deviceId).isEqualTo("ABC-123")
                 assertThat(state.deviceName).isEqualTo("Test Device")
                 assertThat(state.imageUrl).isEqualTo("https://example.com/image.bmp")
+                assertThat(state.isConfigured).isFalse()
+                assertThat(state.canGoPrevious).isFalse()
+                assertThat(state.canGoNext).isFalse()
+                assertThat(state.currentImageIndex).isEqualTo(0)
+                assertThat(state.totalImages).isEqualTo(1)
                 assertThat(state.refreshState).isInstanceOf(DevicePreviewScreen.RefreshState.Idle::class)
+                assertThat(state.loadNextState).isInstanceOf(DevicePreviewScreen.LoadNextState.Idle::class)
+            }
+        }
+
+    @Test
+    fun `presenter enables next navigation when device token is configured`() =
+        runTest {
+            val navigator = FakeNavigator(testScreen)
+            val apiService = FakeApiService()
+            val tokenRepository = FakeDeviceTokenRepository(initialTokens = mapOf("ABC-123" to "device-token-123"))
+            val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
+
+            presenter.test {
+                // Initial unconfigured frame before LaunchedEffect runs
+                val initialState = awaitItem()
+                assertThat(initialState.isConfigured).isFalse()
+
+                // State after LaunchedEffect checks device token
+                val configuredState = awaitItem()
+                assertThat(configuredState.isConfigured).isTrue()
+                assertThat(configuredState.canGoPrevious).isFalse()
+                assertThat(configuredState.canGoNext).isTrue()
+                assertThat(configuredState.currentImageIndex).isEqualTo(0)
+                assertThat(configuredState.totalImages).isEqualTo(1)
             }
         }
 
@@ -75,10 +107,11 @@ class DevicePreviewScreenTest {
             val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
 
             presenter.test {
-                val initialState = awaitItem()
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
 
                 // Trigger refresh
-                initialState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
+                configuredState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
 
                 // Wait for refreshing state
                 val refreshingState = awaitItem()
@@ -109,10 +142,11 @@ class DevicePreviewScreenTest {
             val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
 
             presenter.test {
-                val initialState = awaitItem()
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
 
                 // Trigger refresh
-                initialState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
+                configuredState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
 
                 // Wait for refreshing state
                 val refreshingState = awaitItem()
@@ -142,10 +176,11 @@ class DevicePreviewScreenTest {
             val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
 
             presenter.test {
-                val initialState = awaitItem()
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
 
                 // Trigger refresh
-                initialState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
+                configuredState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
 
                 // Wait for refreshing state
                 val refreshingState = awaitItem()
@@ -175,10 +210,11 @@ class DevicePreviewScreenTest {
             val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
 
             presenter.test {
-                val initialState = awaitItem()
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
 
                 // Trigger refresh
-                initialState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
+                configuredState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
 
                 // Wait for refreshing state
                 val refreshingState = awaitItem()
@@ -221,19 +257,19 @@ class DevicePreviewScreenTest {
         }
 
     @Test
-    fun `refresh image handles null image URL in response`() =
+    fun `next image clicked calls getDisplay API when at latest image and updates cache`() =
         runTest {
             val navigator = FakeNavigator(testScreen)
             val apiService =
                 FakeApiService(
-                    displayResponse =
+                    nextDisplayResponse =
                         ApiResult.success(
                             Display(
                                 status = 200,
                                 refreshRate = 300,
-                                imageUrl = null, // No image URL
-                                filename = null,
-                                renderedAt = null,
+                                imageUrl = "https://example.com/screen2.bmp",
+                                filename = "screen2.bmp",
+                                renderedAt = "2024-10-23T00:05:00Z",
                             ),
                         ),
                 )
@@ -244,21 +280,183 @@ class DevicePreviewScreenTest {
             val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
 
             presenter.test {
-                val initialState = awaitItem()
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
+                assertThat(configuredState.totalImages).isEqualTo(1)
+                assertThat(configuredState.currentImageIndex).isEqualTo(0)
+                assertThat(configuredState.canGoPrevious).isFalse()
 
-                // Trigger refresh
-                initialState.eventSink(DevicePreviewScreen.Event.RefreshImageClicked)
+                // Trigger NextImageClicked
+                configuredState.eventSink(DevicePreviewScreen.Event.NextImageClicked)
 
-                // Wait for refreshing state
-                val refreshingState = awaitItem()
-                assertThat(refreshingState.refreshState).isInstanceOf(DevicePreviewScreen.RefreshState.Refreshing::class)
+                // Wait for loading state
+                val loadingState = awaitItem()
+                assertThat(loadingState.isLoadingNext).isTrue()
+
+                // Wait for success state
+                val successState = awaitItem()
+                assertThat(successState.isLoadingNext).isFalse()
+                assertThat(successState.imageUrl).isEqualTo("https://example.com/screen2.bmp")
+                assertThat(successState.totalImages).isEqualTo(2)
+                assertThat(successState.currentImageIndex).isEqualTo(1)
+                assertThat(successState.canGoPrevious).isTrue()
+
+                val loadNext = successState.loadNextState as DevicePreviewScreen.LoadNextState.Success
+                assertThat(loadNext.message).isEqualTo("Next display image loaded")
+            }
+        }
+
+    @Test
+    fun `navigation moves back and forward through cache without network calls`() =
+        runTest {
+            val navigator = FakeNavigator(testScreen)
+            val apiService =
+                FakeApiService(
+                    nextDisplayResponse =
+                        ApiResult.success(
+                            Display(
+                                status = 200,
+                                refreshRate = 300,
+                                imageUrl = "https://example.com/screen2.bmp",
+                                filename = "screen2.bmp",
+                                renderedAt = "2024-10-23T00:05:00Z",
+                            ),
+                        ),
+                )
+            val tokenRepository =
+                FakeDeviceTokenRepository(
+                    initialTokens = mapOf("ABC-123" to "device-token-123"),
+                )
+            val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
+
+            presenter.test {
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
+
+                // 1. Fetch screen 2
+                configuredState.eventSink(DevicePreviewScreen.Event.NextImageClicked)
+                awaitItem() // Loading
+                val screen2State = awaitItem()
+                assertThat(screen2State.imageUrl).isEqualTo("https://example.com/screen2.bmp")
+                assertThat(screen2State.currentImageIndex).isEqualTo(1)
+                assertThat(screen2State.totalImages).isEqualTo(2)
+
+                // 2. Navigate back to screen 1
+                screen2State.eventSink(DevicePreviewScreen.Event.PreviousImageClicked)
+                val backToScreen1State = awaitItem()
+                assertThat(backToScreen1State.imageUrl).isEqualTo("https://example.com/image.bmp")
+                assertThat(backToScreen1State.currentImageIndex).isEqualTo(0)
+                assertThat(backToScreen1State.totalImages).isEqualTo(2)
+                assertThat(backToScreen1State.canGoPrevious).isFalse()
+
+                // 3. Navigate forward to screen 2 from cache
+                backToScreen1State.eventSink(DevicePreviewScreen.Event.NextImageClicked)
+                val forwardToScreen2State = awaitItem()
+                assertThat(forwardToScreen2State.imageUrl).isEqualTo("https://example.com/screen2.bmp")
+                assertThat(forwardToScreen2State.currentImageIndex).isEqualTo(1)
+                assertThat(forwardToScreen2State.totalImages).isEqualTo(2)
+                assertThat(forwardToScreen2State.canGoPrevious).isTrue()
+            }
+        }
+
+    @Test
+    fun `next image handles getDisplay error gracefully`() =
+        runTest {
+            val navigator = FakeNavigator(testScreen)
+            val apiService =
+                FakeApiService(
+                    nextDisplayResponse = ApiResult.httpFailure(500, null),
+                )
+            val tokenRepository =
+                FakeDeviceTokenRepository(
+                    initialTokens = mapOf("ABC-123" to "device-token-123"),
+                )
+            val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
+
+            presenter.test {
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
+
+                // Trigger NextImageClicked
+                configuredState.eventSink(DevicePreviewScreen.Event.NextImageClicked)
+
+                // Wait for loading state
+                val loadingState = awaitItem()
+                assertThat(loadingState.isLoadingNext).isTrue()
 
                 // Wait for error state
                 val errorState = awaitItem()
-                assertThat(errorState.refreshState).isInstanceOf(DevicePreviewScreen.RefreshState.Error::class)
+                assertThat(errorState.isLoadingNext).isFalse()
+                assertThat(errorState.imageUrl).isEqualTo("https://example.com/image.bmp")
+                assertThat(errorState.totalImages).isEqualTo(1)
+                assertThat(errorState.currentImageIndex).isEqualTo(0)
+                assertThat(errorState.loadNextState).isInstanceOf(DevicePreviewScreen.LoadNextState.Error::class)
 
-                val error = errorState.refreshState as DevicePreviewScreen.RefreshState.Error
-                assertThat(error.message).isEqualTo("No preview image available")
+                val error = errorState.loadNextState as DevicePreviewScreen.LoadNextState.Error
+                assertThat(error.message).isEqualTo("Server error. Please try again later.")
+            }
+        }
+
+    @Test
+    fun `back click pops result with newImageUrl when image has changed`() =
+        runTest {
+            val navigator = FakeNavigator(testScreen)
+            val apiService =
+                FakeApiService(
+                    nextDisplayResponse =
+                        ApiResult.success(
+                            Display(
+                                status = 200,
+                                refreshRate = 300,
+                                imageUrl = "https://example.com/screen2.bmp",
+                                filename = "screen2.bmp",
+                                renderedAt = "2024-10-23T00:05:00Z",
+                            ),
+                        ),
+                )
+            val tokenRepository =
+                FakeDeviceTokenRepository(
+                    initialTokens = mapOf("ABC-123" to "device-token-123"),
+                )
+            val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
+
+            presenter.test {
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
+
+                // Fetch next image
+                configuredState.eventSink(DevicePreviewScreen.Event.NextImageClicked)
+                awaitItem() // Loading
+                val updatedState = awaitItem()
+
+                // Click back
+                updatedState.eventSink(DevicePreviewScreen.Event.BackClicked)
+
+                val popResult = navigator.awaitPop()
+                val result = popResult.result as DevicePreviewScreen.Result
+                assertThat(result.deviceId).isEqualTo("ABC-123")
+                assertThat(result.newImageUrl).isEqualTo("https://example.com/screen2.bmp")
+            }
+        }
+
+    @Test
+    fun `back click pops result with null newImageUrl when image did not change`() =
+        runTest {
+            val navigator = FakeNavigator(testScreen)
+            val apiService = FakeApiService()
+            val tokenRepository = FakeDeviceTokenRepository()
+            val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
+
+            presenter.test {
+                val initialState = awaitItem()
+
+                // Click back without changing image
+                initialState.eventSink(DevicePreviewScreen.Event.BackClicked)
+
+                val popResult = navigator.awaitPop()
+                val result = popResult.result as DevicePreviewScreen.Result
+                assertThat(result.deviceId).isEqualTo("ABC-123")
+                assertThat(result.newImageUrl).isNull()
             }
         }
 }
@@ -277,6 +475,16 @@ private class FakeApiService(
                 renderedAt = "2024-10-23T00:00:00Z",
             ),
         ),
+    private val nextDisplayResponse: ApiResult<Display, ApiError> =
+        ApiResult.success(
+            Display(
+                status = 200,
+                refreshRate = 300,
+                imageUrl = "https://example.com/next-image.bmp",
+                filename = "next-image.bmp",
+                renderedAt = "2024-10-23T00:00:00Z",
+            ),
+        ),
 ) : TrmnlApiService {
     override suspend fun getDevices(authorization: String) = throw NotImplementedError("Not needed for DevicePreviewScreen tests")
 
@@ -286,6 +494,8 @@ private class FakeApiService(
     ) = throw NotImplementedError("Not needed for DevicePreviewScreen tests")
 
     override suspend fun getDisplayCurrent(deviceApiKey: String): ApiResult<Display, ApiError> = displayResponse
+
+    override suspend fun getDisplay(deviceApiKey: String): ApiResult<Display, ApiError> = nextDisplayResponse
 
     override suspend fun userInfo(authorization: String) = throw NotImplementedError("Not needed for DevicePreviewScreen tests")
 

--- a/app/src/test/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreenTest.kt
+++ b/app/src/test/java/ink/trmnl/android/buddy/ui/devices/TrmnlDevicesScreenTest.kt
@@ -435,6 +435,9 @@ private class FakeApiService(
     override suspend fun getDisplayCurrent(deviceApiKey: String): ApiResult<Display, ApiError> =
         ApiResult.success(Display(200, 300, null, null, null))
 
+    override suspend fun getDisplay(deviceApiKey: String): ApiResult<Display, ApiError> =
+        ApiResult.success(Display(200, 300, null, null, null))
+
     override suspend fun userInfo(authorization: String): ApiResult<UserResponse, ApiError> = throw NotImplementedError()
 
     override suspend fun getRecipes(


### PR DESCRIPTION
Closes #517

### Overview
This PR implements next display image loading, display history caching, and backward/forward navigation in the TRMNL device full-screen preview.

### Changes
- **API ()**:
  - Added `getDisplay(@Header("Access-Token") deviceApiKey: String): ApiResult<Display, ApiError>` in `TrmnlApiService` to query `GET /api/display`.
  - Added unit test suite in `TrmnlDisplayApiTest` for success, 401, and network failure responses.
- **Presenter & Caching (`DevicePreviewPresenter`)**:
  - Gated navigation actions on device API token configuration (`deviceTokenRepository.hasDeviceToken`).
  - Maintains retained in-memory session cache of viewed/fetched display images and current image index.
  - `PreviousImageClicked` navigates back in cache without network calls.
  - `NextImageClicked` advances in cache or triggers `apiService.getDisplay(deviceToken)` when at the latest cached image, appending new images to history.
  - Propagates `DevicePreviewScreen.Result(deviceId, newImageUrl)` on back navigation.
- **UI (`DevicePreviewContent`)**:
  - Added floating bottom navigation pill (`Alignment.BottomCenter`) displaying Previous (`<`), Page Counter (`X / Y`), and Next (`>`).
  - Next button displays a `CircularProgressIndicator` while loading from the API.
  - Floating pill is hidden if the device does not have an API key configured.
- **Testing (`DevicePreviewScreenTest`)**:
  - Added 6 new presenter tests for cache navigation, API fetching, token gating, error handling, and pop results.

### Verification
- [x] `./gradlew :api:test` passes (100%)
- [x] `./gradlew :app:testDebugUnitTest` passes (100%)
- [x] `./gradlew formatKotlin` verified
- [x] `./gradlew assembleDebug` built cleanly