### PR TITLE
feat(preview): add smart sleep mode and duplicate screen detection

### DIFF
--- a/api/src/main/java/ink/trmnl/android/buddy/api/models/Display.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/models/Display.kt
@@ -54,4 +54,9 @@ data class Display(
      */
     @SerialName("rendered_at")
     val renderedAt: String? = null,
+    /**
+     * Special function or mode active on the device (e.g., "identify", "sleep", or null).
+     */
+    @SerialName("special_function")
+    val specialFunction: String? = null,
 )

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewContent.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewContent.kt
@@ -109,21 +109,18 @@ fun DevicePreviewContent(
         }
     }
 
-    // Handle load next state with snackbar messages
+    // Handle load next state with snackbar messages (errors only)
     LaunchedEffect(state.loadNextState) {
         when (val loadNextState = state.loadNextState) {
-            is DevicePreviewScreen.LoadNextState.Success -> {
-                snackbarHostState.showSnackbar(loadNextState.message)
-                state.eventSink(DevicePreviewScreen.Event.DismissLoadNextSnackbar)
-            }
             is DevicePreviewScreen.LoadNextState.Error -> {
                 snackbarHostState.showSnackbar(loadNextState.message)
                 state.eventSink(DevicePreviewScreen.Event.DismissLoadNextSnackbar)
             }
             DevicePreviewScreen.LoadNextState.Idle,
             DevicePreviewScreen.LoadNextState.Loading,
+            is DevicePreviewScreen.LoadNextState.Success,
             -> {
-                // No action needed
+                // No snackbar on success or loading
             }
         }
     }

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewPresenter.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewPresenter.kt
@@ -125,7 +125,9 @@ class DevicePreviewPresenter
                                                 } else if (isSameScreen) {
                                                     loadNextState =
                                                         DevicePreviewScreen.LoadNextState.Error(
-                                                            message = "No new screen to display. Device may have only one screen in rotation.",
+                                                            message =
+                                                                "No new screen to display. " +
+                                                                    "Device may have only one screen in rotation.",
                                                         )
                                                 } else {
                                                     cachedImages = cachedImages + newImageUrl

--- a/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewPresenter.kt
+++ b/app/src/main/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewPresenter.kt
@@ -109,16 +109,29 @@ class DevicePreviewPresenter
                                     when (val result = apiService.getDisplay(token)) {
                                         is ApiResult.Success -> {
                                             val newImageUrl = result.value.imageUrl
+                                            val display = result.value
                                             if (newImageUrl != null) {
-                                                if (newImageUrl != currentImageUrl) {
+                                                val isSleeping =
+                                                    display.filename?.equals("sleep", ignoreCase = true) == true ||
+                                                        display.specialFunction?.equals("sleep", ignoreCase = true) == true
+                                                val isSameScreen =
+                                                    normalizeImageUrl(newImageUrl) == normalizeImageUrl(currentImageUrl)
+
+                                                if (isSleeping) {
+                                                    loadNextState =
+                                                        DevicePreviewScreen.LoadNextState.Error(
+                                                            message = "Device is in sleep mode. No new screen available.",
+                                                        )
+                                                } else if (isSameScreen) {
+                                                    loadNextState =
+                                                        DevicePreviewScreen.LoadNextState.Error(
+                                                            message = "No new screen to display. Device may have only one screen in rotation.",
+                                                        )
+                                                } else {
                                                     cachedImages = cachedImages + newImageUrl
                                                     currentImageIndex = cachedImages.lastIndex
+                                                    loadNextState = DevicePreviewScreen.LoadNextState.Idle
                                                 }
-                                                loadNextState =
-                                                    DevicePreviewScreen.LoadNextState.Success(
-                                                        newImageUrl = newImageUrl,
-                                                        message = "Next display image loaded",
-                                                    )
                                             } else {
                                                 loadNextState =
                                                     DevicePreviewScreen.LoadNextState.Error(
@@ -205,3 +218,26 @@ class DevicePreviewPresenter
             ): DevicePreviewPresenter
         }
     }
+
+/**
+ * Normalizes an image URL by stripping dynamic query parameters to compare the underlying image asset.
+ *
+ * TRMNL device display API responses (`GET /api/display` and `GET /api/display/current`) provide
+ * pre-signed cloud storage URLs (e.g., AWS S3 or DigitalOcean Spaces) that contain dynamic timestamp,
+ * credential, and cryptographic signature query parameters (such as `X-Amz-Date`, `X-Amz-Signature`, `X-Amz-Expires`).
+ * Because these query parameters change on every HTTP request even when the underlying image has not changed,
+ * comparing full URL strings directly falsely indicates that a new image was generated.
+ *
+ * Example:
+ * ```
+ * Full URL:
+ *   https://trmnl-screens.nyc3.digitaloceanspaces.com/vsgnimt6q3z4giloww5cmmb7iw0s?response-content-disposition=inline&X-Amz-Date=20260817T072931Z&X-Amz-Signature=abc123
+ *
+ * Normalized:
+ *   https://trmnl-screens.nyc3.digitaloceanspaces.com/vsgnimt6q3z4giloww5cmmb7iw0s
+ * ```
+ *
+ * @param url The raw image URL string.
+ * @return The base URL string without query parameters.
+ */
+internal fun normalizeImageUrl(url: String): String = url.substringBefore('?')

--- a/app/src/test/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreenTest.kt
+++ b/app/src/test/java/ink/trmnl/android/buddy/ui/devicepreview/DevicePreviewScreenTest.kt
@@ -300,9 +300,7 @@ class DevicePreviewScreenTest {
                 assertThat(successState.totalImages).isEqualTo(2)
                 assertThat(successState.currentImageIndex).isEqualTo(1)
                 assertThat(successState.canGoPrevious).isTrue()
-
-                val loadNext = successState.loadNextState as DevicePreviewScreen.LoadNextState.Success
-                assertThat(loadNext.message).isEqualTo("Next display image loaded")
+                assertThat(successState.loadNextState).isInstanceOf(DevicePreviewScreen.LoadNextState.Idle::class)
             }
         }
 
@@ -457,6 +455,117 @@ class DevicePreviewScreenTest {
                 val result = popResult.result as DevicePreviewScreen.Result
                 assertThat(result.deviceId).isEqualTo("ABC-123")
                 assertThat(result.newImageUrl).isNull()
+            }
+        }
+
+    @Test
+    fun `normalizeImageUrl strips dynamic query parameters from signed storage URLs`() {
+        val s3SignedUrl =
+            "https://trmnl-screens.nyc3.digitaloceanspaces.com/vsgnimt6q3z4giloww5cmmb7iw0s?" +
+                "response-content-disposition=inline%3B%20filename%3D%22plugin-aabc0b%22&" +
+                "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260817T072931Z&X-Amz-Signature=abc123"
+        assertThat(normalizeImageUrl(s3SignedUrl))
+            .isEqualTo("https://trmnl-screens.nyc3.digitaloceanspaces.com/vsgnimt6q3z4giloww5cmmb7iw0s")
+
+        val standardUrl = "https://example.com/image.bmp"
+        assertThat(normalizeImageUrl(standardUrl)).isEqualTo("https://example.com/image.bmp")
+    }
+
+    @Test
+    fun `next image detects sleep mode and displays friendly error without duplicating cache`() =
+        runTest {
+            val navigator = FakeNavigator(testScreen)
+            val apiService =
+                FakeApiService(
+                    nextDisplayResponse =
+                        ApiResult.success(
+                            Display(
+                                status = 0,
+                                refreshRate = 34565,
+                                imageUrl = "https://trmnl-screens.nyc3.digitaloceanspaces.com/sleep-asset?sig=new",
+                                filename = "sleep",
+                                specialFunction = "identify",
+                            ),
+                        ),
+                )
+            val tokenRepository =
+                FakeDeviceTokenRepository(
+                    initialTokens = mapOf("ABC-123" to "device-token-123"),
+                )
+            val presenter = DevicePreviewPresenter(testScreen, navigator, apiService, tokenRepository)
+
+            presenter.test {
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
+
+                // Trigger next image
+                configuredState.eventSink(DevicePreviewScreen.Event.NextImageClicked)
+
+                // Wait for loading state
+                val loadingState = awaitItem()
+                assertThat(loadingState.isLoadingNext).isTrue()
+
+                // Wait for error state detecting sleep mode
+                val errorState = awaitItem()
+                assertThat(errorState.isLoadingNext).isFalse()
+                assertThat(errorState.totalImages).isEqualTo(1)
+                assertThat(errorState.currentImageIndex).isEqualTo(0)
+                assertThat(errorState.loadNextState).isInstanceOf(DevicePreviewScreen.LoadNextState.Error::class)
+
+                val error = errorState.loadNextState as DevicePreviewScreen.LoadNextState.Error
+                assertThat(error.message).isEqualTo("Device is in sleep mode. No new screen available.")
+            }
+        }
+
+    @Test
+    fun `next image detects same underlying screen despite dynamic signed query params`() =
+        runTest {
+            val screenWithSignedUrl =
+                DevicePreviewScreen(
+                    deviceId = "ABC-123",
+                    deviceName = "Test Device",
+                    imageUrl = "https://trmnl-screens.nyc3.digitaloceanspaces.com/vsgnimt6q3z4giloww5cmmb7iw0s?sig=request1",
+                )
+            val navigator = FakeNavigator(screenWithSignedUrl)
+            val apiService =
+                FakeApiService(
+                    nextDisplayResponse =
+                        ApiResult.success(
+                            Display(
+                                status = 0,
+                                refreshRate = 16237,
+                                imageUrl =
+                                    "https://trmnl-screens.nyc3.digitaloceanspaces.com/vsgnimt6q3z4giloww5cmmb7iw0s?sig=request2_different_timestamp",
+                                filename = "plugin-aabc0b",
+                            ),
+                        ),
+                )
+            val tokenRepository =
+                FakeDeviceTokenRepository(
+                    initialTokens = mapOf("ABC-123" to "device-token-123"),
+                )
+            val presenter = DevicePreviewPresenter(screenWithSignedUrl, navigator, apiService, tokenRepository)
+
+            presenter.test {
+                awaitItem() // Initial frame
+                val configuredState = awaitItem()
+
+                // Trigger next image
+                configuredState.eventSink(DevicePreviewScreen.Event.NextImageClicked)
+
+                // Wait for loading state
+                val loadingState = awaitItem()
+                assertThat(loadingState.isLoadingNext).isTrue()
+
+                // Wait for error state detecting same screen
+                val errorState = awaitItem()
+                assertThat(errorState.isLoadingNext).isFalse()
+                assertThat(errorState.totalImages).isEqualTo(1)
+                assertThat(errorState.currentImageIndex).isEqualTo(0)
+                assertThat(errorState.loadNextState).isInstanceOf(DevicePreviewScreen.LoadNextState.Error::class)
+
+                val error = errorState.loadNextState as DevicePreviewScreen.LoadNextState.Error
+                assertThat(error.message).isEqualTo("No new screen to display. Device may have only one screen in rotation.")
             }
         }
 }


### PR DESCRIPTION
### Summary
Implements smart sleep mode and duplicate screen detection when loading next display images in full-screen device preview.

### Details & Motivation
1. **Dynamic Signed Storage URLs**: TRMNL display responses from S3/DigitalOcean Spaces include query parameters (`X-Amz-Date`, `X-Amz-Signature`) that change on every API call. Direct URL string comparison previously caused identical images to be treated as new ones, duplicating cache entries.
2. **Normalized URL Helper (`normalizeImageUrl`)**: Added with comprehensive KDoc explaining how query parameters are stripped for underlying asset comparison.
3. **Smart Sleep & Duplicate Detection**:
   - When `display.filename == "sleep"` or `special_function == "sleep"`, the device is in sleep mode: notifies user (*"Device is in sleep mode. No new screen available."*) without advancing or duplicating cache history.
   - When the normalized base URL matches the current screen (`normalizeImageUrl(new) == normalizeImageUrl(current)`), the rotation did not advance: notifies user (*"No new screen to display. Device may have only one screen in rotation."*) without duplicating cache history.
4. **UX Refinement**: Removed redundant *"Next display image loaded"* snackbar on successful next image fetch for a smoother reading flow.

### Verification
- [x] Unit tests added in `DevicePreviewScreenTest` for `normalizeImageUrl`, sleep mode detection, and duplicate detection
- [x] `./gradlew testDebugUnitTest` passes (100%)
- [x] Tested live on emulator and verified via Logcat


### Sample

```json
    {
      "status": 0,
      "image_url": "https://trmnl-screens.nyc3.digitaloceanspaces.com/...",
      "filename": "sleep",
      "refresh_rate": 16023,
      "reset_firmware": false,
      "update_firmware": false,
      "special_function": "identify"
    }
```