### PR TITLE
build(deps): upgrade kotlinx-kover to 0.9.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ kotlinter = "5.2.0"
 
 # Kover - Kotlin code coverage
 # https://github.com/Kotlin/kotlinx-kover
-kover = "0.9.1"
+kover = "0.9.9"
 lifecycleRuntimeKtx = "2.9.4"
 metro = "0.6.8"
 androidxWork = "2.10.5"


### PR DESCRIPTION
## Summary
Upgrades `kotlinx-kover` from `0.9.1` to `0.9.9`.

### Changes
- Updated `kover = "0.9.9"` in `gradle/libs.versions.toml`.

### Verification
- Tested all tasks: `./gradlew koverLog koverXmlReport koverHtmlReport`.
- Ran linter and formatting: `./gradlew formatKotlin lintKotlin`.
- All tests and report generation succeeded.