### PR TITLE
test(api): enhance UserAgentProvider with default parameters and comprehensive tests

### DIFF
--- a/api/src/main/java/ink/trmnl/android/buddy/api/UserAgentProvider.kt
+++ b/api/src/main/java/ink/trmnl/android/buddy/api/UserAgentProvider.kt
@@ -22,13 +22,21 @@ object UserAgentProvider {
      * Generates a user agent string with the provided app version.
      *
      * @param appVersion The application version (e.g., "1.6.0")
-     * @return Formatted user agent string
+     * @param androidVersion The Android SDK version (defaults to [Build.VERSION.SDK_INT])
+     * @param deviceModel The device model name (defaults to [Build.MODEL])
+     * @param okhttpVersion The OkHttp library version (defaults to [OkHttp.VERSION])
+     * @return Formatted and sanitized user agent string
      */
-    fun getUserAgent(appVersion: String): String {
-        val androidVersion = Build.VERSION.SDK_INT
-        val deviceModel = Build.MODEL ?: "Unknown"
-        val okhttpVersion = OkHttp.VERSION
+    fun getUserAgent(
+        appVersion: String,
+        androidVersion: Int = Build.VERSION.SDK_INT,
+        deviceModel: String? = Build.MODEL,
+        okhttpVersion: String = OkHttp.VERSION,
+    ): String {
+        val sanitizedVersion = appVersion.trim().ifBlank { "unknown" }
+        val sanitizedModel = deviceModel?.trim()?.ifBlank { "Unknown" } ?: "Unknown"
+        val sanitizedOkHttp = okhttpVersion.trim().ifBlank { "unknown" }
 
-        return "$APP_NAME/$appVersion (Android $androidVersion; $deviceModel) OkHttp/$okhttpVersion"
+        return "$APP_NAME/$sanitizedVersion (Android $androidVersion; $sanitizedModel) OkHttp/$sanitizedOkHttp"
     }
 }

--- a/api/src/test/java/ink/trmnl/android/buddy/api/UserAgentProviderTest.kt
+++ b/api/src/test/java/ink/trmnl/android/buddy/api/UserAgentProviderTest.kt
@@ -3,6 +3,7 @@ package ink.trmnl.android.buddy.api
 import android.os.Build
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.matches
 import assertk.assertions.startsWith
@@ -117,5 +118,78 @@ class UserAgentProviderTest {
         assertThat(userAgent).contains("unknown")
         assertThat(userAgent).contains("Android")
         assertThat(userAgent).contains("OkHttp")
+    }
+
+    @Test
+    fun `getUserAgent with custom parameters formats exact expected string`() {
+        val userAgent =
+            UserAgentProvider.getUserAgent(
+                appVersion = "2.15.0",
+                androidVersion = 34,
+                deviceModel = "Pixel 8",
+                okhttpVersion = "5.1.0",
+            )
+
+        assertThat(userAgent).isEqualTo("TrmnlAndroidBuddy/2.15.0 (Android 34; Pixel 8) OkHttp/5.1.0")
+    }
+
+    @Test
+    fun `getUserAgent with blank app version falls back to unknown`() {
+        val userAgent =
+            UserAgentProvider.getUserAgent(
+                appVersion = "   ",
+                androidVersion = 33,
+                deviceModel = "Galaxy S23",
+                okhttpVersion = "5.0.0",
+            )
+
+        assertThat(userAgent).isEqualTo("TrmnlAndroidBuddy/unknown (Android 33; Galaxy S23) OkHttp/5.0.0")
+    }
+
+    @Test
+    fun `getUserAgent with null or blank device model falls back to Unknown`() {
+        val userAgentWithNull =
+            UserAgentProvider.getUserAgent(
+                appVersion = "1.0.0",
+                androidVersion = 30,
+                deviceModel = null,
+                okhttpVersion = "4.9.0",
+            )
+        val userAgentWithBlank =
+            UserAgentProvider.getUserAgent(
+                appVersion = "1.0.0",
+                androidVersion = 30,
+                deviceModel = "   ",
+                okhttpVersion = "4.9.0",
+            )
+
+        assertThat(userAgentWithNull).isEqualTo("TrmnlAndroidBuddy/1.0.0 (Android 30; Unknown) OkHttp/4.9.0")
+        assertThat(userAgentWithBlank).isEqualTo("TrmnlAndroidBuddy/1.0.0 (Android 30; Unknown) OkHttp/4.9.0")
+    }
+
+    @Test
+    fun `getUserAgent trims surrounding whitespace from all components`() {
+        val userAgent =
+            UserAgentProvider.getUserAgent(
+                appVersion = " 2.0.0 ",
+                androidVersion = 31,
+                deviceModel = " Pixel 6 Pro ",
+                okhttpVersion = " 5.1.0 ",
+            )
+
+        assertThat(userAgent).isEqualTo("TrmnlAndroidBuddy/2.0.0 (Android 31; Pixel 6 Pro) OkHttp/5.1.0")
+    }
+
+    @Test
+    fun `getUserAgent with blank okhttp version falls back to unknown`() {
+        val userAgent =
+            UserAgentProvider.getUserAgent(
+                appVersion = "1.0.0",
+                androidVersion = 32,
+                deviceModel = "Pixel 7",
+                okhttpVersion = "   ",
+            )
+
+        assertThat(userAgent).isEqualTo("TrmnlAndroidBuddy/1.0.0 (Android 32; Pixel 7) OkHttp/unknown")
     }
 }


### PR DESCRIPTION
## Summary
Enhances `UserAgentProvider.kt` by supporting default parameters for `androidVersion`, `deviceModel`, and `okhttpVersion` along with input sanitization and comprehensive unit tests.

### Changes
- **`UserAgentProvider.kt`**:
  - Added default parameters `androidVersion: Int = Build.VERSION.SDK_INT`, `deviceModel: String? = Build.MODEL`, and `okhttpVersion: String = OkHttp.VERSION`.
  - Added sanitization to trim surrounding whitespace and provide safe fallbacks for empty/blank values (`"unknown"` / `"Unknown"`).
- **`UserAgentProviderTest.kt`**:
  - Added unit tests for custom parameters, blank fallbacks, null/blank device models, and whitespace trimming.

### Verification
- Ran `./gradlew formatKotlin lintKotlin testDebugUnitTest koverLog koverXmlReport` (all 680+ tests passing, 100% coverage on `UserAgentProvider`).